### PR TITLE
Add THP charter translations and refinements

### DIFF
--- a/[Paramount]Workflow/【最重要】The Horizon Protocol (THP)/1st-The Horizon Protocol Seven Documents/Japanese/THP-1_en.md
+++ b/[Paramount]Workflow/【最重要】The Horizon Protocol (THP)/1st-The Horizon Protocol Seven Documents/Japanese/THP-1_en.md
@@ -1,0 +1,95 @@
+REFINED_BY_CODEX: 2025-09-17T00:00:00Z
+REFINED_BY_CODEX: 2025-09-17T00:00:00Z
+
+AUDIT_TRAIL:
+AUDIT_TRAIL:
+
+- 2025-09-17T00:00:00Z 翻訳 (JP→EN) と書式整備を実施。
+- 2025-09-17T00:00:00Z Executed JP-to-EN translation and formatting alignment.
+
+# World Redefinition Charter - 世界再定義宣言
+# World Redefinition Charter - World Redefinition Declaration
+
+## 研究版 (Detailed Version)
+## Research Edition (Detailed Version)
+
+### 序文：旧世界の死亡診断書
+### Preamble: Death Certificate of the Old World
+
+20世紀に築かれた「国家の物語」や「民族の神話」は、その内部矛盾と歴史的欺瞞によって自壊を始めている。日本の「国際貢献」、英国の「消えぬ栄光」、イタリアの「歴史的和解」、イスラエルの「約束の地」。これらはいずれも、自らにとって都合の良い歴史解釈に依拠し、困難な過去の直視を避けることで、今日の深刻な世界的対立と機能不全を招いた。
+The "national stories" and "ethnic myths" constructed in the twentieth century are beginning to collapse under their internal contradictions and historical deceit. Japan's "international contribution," Britain's "glory that never fades," Italy's "historic reconciliation," and Israel's "promised land" all rely on convenient readings of history; by averting their gaze from painful pasts, they have led to today's severe global confrontation and dysfunction.
+
+対照的に、ドイツが示したのは「責任のナラティブ」である。自らが犯した最悪の過去から目を背けず、それを国家アイデンティティの中心に統合し、恒久的な責任として背負うことで、彼らは戦後欧州における信頼の礎を築き得た。この比較が示す真理はただ一つである。「困難な過去を回避する物語は、必ず失敗する」。
+By contrast, Germany offered a "narrative of responsibility." By refusing to avert its eyes from the worst deeds of its past, integrating that burden into the core of its national identity, and carrying it as a perpetual responsibility, Germany built the foundation of trust in postwar Europe. This comparison reveals a single truth: any story that sidesteps a painful past is destined to fail.
+
+ワルプルギス後の世界において、もはや神話や歴史の選択的解釈は、世界秩序を束ねる力を持たない。新秩序の唯一の基盤は、THP倫理憲章が示す「秩序を破壊し、人倫を踏みにじる者を罰する」という、普遍的かつ透明なルールである。本宣言は、旧世界の物語に対する死亡診断書であり、THPが主導する新秩序の出生証明書となる。
+In the post-Walpurgis world, myth and selective readings of history no longer have the power to hold the global order together. The sole foundation of the new order is the universal and transparent rule set out in the THP Ethics Charter: punish anyone who destroys order or tramples on humanity. This charter serves as the death certificate for the narratives of the old world and the birth certificate for the new order led by THP.
+
+### 第1条：普遍的秩序の優先
+### Article 1: Primacy of Universal Order
+
+新世界における唯一絶対の正義は「秩序の維持」である。民族、宗教、国家、イデオロギーなど、いかなる名目を借りたとしても、秩序そのものを破壊する行為、あるいは人倫に悖る行為は正当化されない。世界の正統な構成員とは、国家の大小や経済力によらず、この普遍的秩序を尊重し、維持する責任を負う全ての主体である。
+The only absolute justice in the new world is the maintenance of order. Regardless of the banners of ethnicity, religion, statehood, or ideology, no act that destroys order itself or violates humanity can be justified. Legitimate members of the world—regardless of size or economic power—are all entities that respect and bear responsibility for sustaining this universal order.
+
+### 第2条：責任の統合と贖罪
+### Article 2: Integration of Responsibility and Atonement
+
+過去に犯された罪は、忘却や相対化によって解消されるものではない。それは「責任」として、国家や民族のアイデンティティに恒久的に統合されねばならない。ドイツの例が示すように、責任の継承こそが未来への信頼を構築する。THPは、この責任の履行を前提として、国際社会への復帰を可能にする「贖罪」の門戸を設ける。
+Crimes committed in the past are not erased through oblivion or relativization. They must be permanently integrated as "responsibility" into the identities of nations and peoples. As Germany's example shows, carrying forward responsibility is what builds trust in the future. THP opens the gateway of "atonement," enabling a return to the international community on the condition that this responsibility is fulfilled.
+
+### 第3条：断罪の不可逆性
+### Article 3: Irreversibility of Condemnation
+
+戦争犯罪、ジェノサイド、人道に対する罪など、THP倫理憲章が「普遍的大罪」と定義する行為は、政治的判断を超えた人類全体による倫理的判決として「断罪」される。この断罪は不可逆の歴史的烙印であり、いかなる時代や政治状況の変化によっても覆ることはない。これは、未来に対する人類の誓約である。
+Acts defined in the THP Ethics Charter as "universal grave crimes"—war crimes, genocide, crimes against humanity—are condemned as ethical judgments rendered by all humanity, beyond political calculation. Such condemnation is an irreversible historical brand that no change in era or political circumstances can overturn. It is humanity's vow to the future.
+
+### 第4条：民族と宗教の水平性
+### Article 4: Horizontal Equality of Peoples and Religions
+
+全ての民族および宗教は、その文化、歴史、価値観において等しく水平であり、優劣は存在しない。その多様性は人類の資産として尊重され、守られる。ただし、他者を否定し、自らの優越を唱え、あるいは暴力を正当化するに至った時、それは民族や宗教ではなく、THPが断罪すべき「カルト」または「暴力装置」と見なされる。共存の基盤は「あなたの正しさと、私の正しさは、共に正しい」という相互承認にある。
+All peoples and religions stand on equal horizontal footing in their cultures, histories, and values; none is superior. Their diversity must be respected and protected as a treasure of humanity. However, once a group denies others, claims its own supremacy, or justifies violence, it is no longer a people or religion but a "cult" or "instrument of violence" that THP shall condemn. The basis of coexistence is mutual recognition that "your rightness and my rightness are both right."
+
+### 第5条：科学的現実主義
+### Article 5: Scientific Empirical Realism
+
+科学は万能ではないが、客観的なデータと検証可能なプロセスに基づく「現実知」として、あらゆる意思決定の基礎に置かれる。特に医療においては、科学的エビデンスに基づく標準治療が最良の選択肢とされ、これを宗教的・文化的理由で妨げることは、生命に対する重大な侵害行為と見なされる。
+Science is not omnipotent, yet as "empirical knowledge" grounded in objective data and verifiable processes, it must undergird all decision-making. In medicine especially, standard treatments based on scientific evidence are deemed the best options, and obstructing them for religious or cultural reasons constitutes a grave violation of life.
+
+### 第6条：未来の物語の共創
+### Article 6: Co-creating the Narrative of the Future
+
+旧世界において国家、民族、宗教が独占してきた「正義」の物語は、その効力を失った。ワルプルギス後の未来を紡ぐ唯一の物語は、THPが掲げる「透明性・公平性・正確性」という三本の柱の下で、全ての主体が共通の秩序を共に編み上げていくプロセスそのものである。
+The narratives of "justice" once monopolized by states, peoples, and religions in the old world have lost their power. The sole narrative that can weave the post-Walpurgis future is the very process in which all actors co-create a shared order under THP's three pillars of transparency, fairness, and accuracy.
+
+### 結語：進化するプロトコル
+### Epilogue: A Protocol in Evolution
+
+本宣言を含むTHPの七つの文書は、完成された教典ではない。これらは、未来の世代が、その時代の現実に合わせて民主的なプロセスを通じて常に書き換えていくべき、進化するプロトコルである。我々が目指すのは完璧な世界の実現ではなく、いかなる時代においても、全ての生命が尊厳を保ち、平和を享受できる世界を、悠久に追い求め続ける不断の努力そのものである。
+The seven THP documents, including this charter, are not completed scriptures. They are evolving protocols that future generations must continually revise through democratic processes to match the realities of their time. Our goal is not a flawless world, but the ceaseless effort to pursue a world where every life can keep its dignity and enjoy peace in any era.
+
+---
+---
+
+## 条文版 (Simplified Version)
+## Simplified Edition (Simplified Version)
+
+- **古い物語の終わり**: 自分に都合のいい歴史解釈や神話はもう通用しない。過去から目を背ける国は失敗する。
+- **End of the Old Stories**: Convenient interpretations of history or myth no longer work; nations that avert their eyes from the past will fail.
+- **新しいルール**: 世界のルールはただ一つ。「秩序を壊す者と、人として許されないことをする者を罰する」。
+- **The New Rule**: The world has a single rule—punish those who shatter order or commit acts no human can permit.
+- **罪と責任**: 過去の罪は忘れず、責任として受け入れ続ける。それが未来への信頼に繋がる。
+- **Guilt and Responsibility**: Never forget past crimes; continue to accept them as responsibility, for that builds trust in the future.
+- **民族と宗教**: どんな民族も宗教も、みんな平等で、優劣はない。「あなたのものも、私のものも、両方正しい」が基本。
+- **Peoples and Religions**: Every people and religion is equal, with no hierarchy; the premise is that "what is right for you and what is right for me are both right."
+- **科学は大事**: 思い込みより、データや事実を信じる。特に医療では、科学的な標準治療が一番。
+- **Science Matters**: Trust data and facts over assumptions; in medicine especially, scientific standard treatment is best.
+- **未来の作り方**: 「透明・公平・正確」をルールに、みんなで新しい物語を作っていく。
+- **Making the Future**: With transparency, fairness, and accuracy as the rules, everyone crafts the new story together.
+- **このルールも完璧じゃない**: この宣言も未来の世代が変えていってOK。大事なのは、平和な世界を目指し続けること。
+- **This Rulebook Isn't Perfect Either**: Future generations may rewrite this charter; what matters is to keep striving for a peaceful world.
+
+## UN rev.2 への遷移（接続）
+## Transition (Integration) into UN rev.2
+
+- 世界再定義は『暫定合意（Provisional Accord）→正式条約』の二段階で UN rev.2 に実装する。
+- The world redefinition will be implemented into UN rev.2 in two stages: from a Provisional Accord to a formal treaty.

--- a/[Paramount]Workflow/【最重要】The Horizon Protocol (THP)/1st-The Horizon Protocol Seven Documents/Japanese/THP-2_en.md
+++ b/[Paramount]Workflow/【最重要】The Horizon Protocol (THP)/1st-The Horizon Protocol Seven Documents/Japanese/THP-2_en.md
@@ -1,0 +1,156 @@
+REFINED_BY_CODEX: 2025-09-17T00:00:00Z
+REFINED_BY_CODEX: 2025-09-17T00:00:00Z
+
+AUDIT_TRAIL:
+AUDIT_TRAIL:
+
+- 2025-09-17T00:00:00Z 翻訳 (JP→EN) と書式整備を実施。
+- 2025-09-17T00:00:00Z Executed JP-to-EN translation and formatting alignment.
+
+# THP-2: Ethics Charter - 倫理憲章
+# THP-2: Ethics Charter - Ethics Charter
+
+### 序文
+### Preamble
+
+本憲章は、The Horizon Protocol (THP) が構築する新世界秩序における倫理的な根幹を定義するものである。旧来の国際法や正義論が機能不全に陥った現実を直視し、「秩序の維持」と「人倫の防衛」を絶対的な基準として設定する。全ての国家、組織、個人は、本憲章の条文に基づき評価され、その行動の是非が判断される。
+This charter defines the ethical foundation of the new world order constructed by The Horizon Protocol (THP). Facing the reality that conventional international law and theories of justice have fallen into dysfunction, it establishes the maintenance of order and the defense of humanity as absolute standards. Every state, organization, and individual will be assessed under the provisions of this charter, which determine whether their actions are permissible.
+
+## 適用範囲
+## Scope of Application
+
+- 本憲章に基づく断罪は、普遍的大罪（大規模民間人殺傷・制度的迫害・侵略の反復）に限る。個別政治争点は対象外とする。
+- Condemnations under this charter are limited to universal grave crimes—large-scale killing of civilians, systemic persecution, and repeated aggression. Individual political disputes fall outside its scope.
+
+## 文化・宗教と普遍的人権の優先順位（民族憲章との接続）
+## Priority Between Culture/Religion and Universal Human Rights (Connected to the People Charter)
+
+- 文化・宗教慣行は保護されるが、普遍的人権に反する場合は当該慣行を無効とする。民族憲章『禁止慣行リスト』に準拠。
+- Cultural and religious practices are protected, but any practice that violates universal human rights is invalidated, in accordance with the People Charter's "Prohibited Practices List."
+
+### 第1条：根本理念：生命の肯定と秩序の優先
+### Article 1: Fundamental Principle—Affirming Life, Prioritizing Order
+
+#### 研究版
+#### Research Edition
+
+全ての生命は、その存在を原則として肯定される。しかし、その肯定は無条件ではなく、THPが定める「秩序」の維持が最優先される。人権は天賦の権利ではなく、THPの秩序とそれに基づく法によって初めて保障される後天的な権利と定義する。秩序を脅かす存在に対して、この権利は制限され得る。
+All life is, in principle, affirmed in its existence. Yet that affirmation is not unconditional; the maintenance of "order" as set by THP takes highest priority. Human rights are defined not as innate endowments but as rights granted by THP's order and the laws derived from it, and thus are guaranteed only under that framework. For any entity that threatens order, these rights may be restricted.
+
+#### 条文版
+#### Simplified Statutory Edition
+
+（研究版の要点を法規文に簡潔化した版。用語はLexiconと一致させる。）
+(This version condenses the research edition into legal language; terminology must match the Lexicon.)
+
+みんなの命はとても大切。でも、みんなが平和に暮らすための「秩序」はもっと大切。人としての権利は、この秩序を守ることで初めて保証される。
+Everyone's life matters, but the "order" that lets everyone live in peace matters even more. Human rights are guaranteed only when that order is protected.
+
+### 第2条：罪の定義：秩序破壊と人倫への挑戦
+### Article 2: Defining Sin—Destroying Order and Defying Humanity
+
+#### 研究版
+#### Research Edition
+
+THPにおける「罪」とは、以下の二つに大別される。
+Within THP, "sins" fall into two broad categories:
+
+1. **秩序そのものを破壊する行為**: 外患誘致、サイバー攻撃による重要インフラの破壊、基軸通貨システムの意図的な攪乱など、THPが定める世界の安定基盤を根底から揺るがす全ての行為。
+1. **Acts that destroy order itself**: inviting foreign hostilities, destroying critical infrastructure through cyberattacks, deliberately disrupting reserve currency systems—any act that shakes the foundations of global stability established by THP.
+
+2. **人倫に悖る行為**: ジェノサイド、無抵抗市民の計画的虐殺、核兵器による恫喝、非人道的な生物・化学兵器の使用など、文明の基盤である人道に対する重大な挑戦。
+2. **Acts that violate humanity**: genocide, the systematic slaughter of unresisting civilians, intimidation by nuclear weapons, or the inhumane use of biological and chemical weapons—grave challenges to the humanitarian foundations of civilization.
+
+#### 条文版
+#### Simplified Statutory Edition
+
+（研究版の要点を法規文に簡潔化した版。用語はLexiconと一致させる。）
+(This version condenses the research edition into legal language; terminology must match the Lexicon.)
+
+THPの世界で「罪」となるのは、次の二つ。
+Two kinds of acts count as "sins" in the THP world:
+
+1. みんなが安心して暮らすためのルールや仕組みを、わざと壊すこと。
+1. Deliberately breaking the rules or systems that let everyone live in safety.
+
+2. 「人として絶対にやってはいけないこと」（→Lexicon参照：人倫）をやること。
+2. Doing anything "no human must ever do" (see the Lexicon entry on humanity).
+
+### 第3条：贖罪：国際社会への復帰
+### Article 3: Atonement—Return to the International Community
+
+#### 研究版
+#### Research Edition
+
+「贖罪」は、過去の罪を清算し、国際社会へ復帰するための公式なプロセスである。これは単なる恩赦ではなく、責任の履行と再発防止への誓約を伴う。承認は、人倫**裁判所**の手続・量刑に基づき、**人倫評議会の名義で宣告**される。四聖は諮問（無投票）。
+"Atonement" is the formal process for settling past crimes and rejoining the international community. It is not a simple pardon; it requires fulfilling responsibilities and pledging to prevent recurrence. Approval follows the procedures and sentencing of the Humanity Court and is proclaimed in the name of the Humanity Council. The Four Sages advise without voting rights.
+
+- **司法機関**: 人倫**裁判所**が訴訟手続・量刑を担い、**最終判決は人倫評議会の名において宣告**する。
+- **Judicial bodies**: The Humanity Court handles litigation and sentencing, and the final judgment is proclaimed in the name of the Humanity Council.
+
+#### 条文版
+#### Simplified Statutory Edition
+
+（研究版の要点を法規文に簡潔化した版。用語はLexiconと一致させる。）
+(This version condenses the research edition into legal language; terminology must match the Lexicon.)
+
+「贖罪」（→Lexicon参照）とは、犯した罪を償い、「ごめんなさい」が世界に認められて、もう一度仲間に入ること。
+"Atonement" (see the Lexicon) means making amends for one’s crimes, having the world accept that apology, and being allowed back into the community.
+
+### 第4. 条：断罪：不可逆の歴史的烙印
+### Article 4: Condemnation—An Irreversible Historical Brand
+
+#### 研究版
+#### Research Edition
+
+「断罪」は、人類に対する普遍的な大罪を犯した主体に対し、救済の余地なく下される最終的な倫理的判決である。人倫裁判所が訴訟手続・量刑を担い、最終判決は人倫評議会の名において宣告する（人倫評議会は審議・勧告を担う）。政治的断罪は排除（普遍的大罪への該当時のみ審理）。この断罪は不可逆の歴史的烙印であり、いかなる時代や政治状況の変化によっても覆ることはない。
+"Condemnation" is the final ethical judgment with no possibility of relief, rendered on any actor that has committed a universal grave crime against humanity. The Humanity Court conducts litigation and sentencing, while the Humanity Council deliberates, advises, and proclaims the final judgment in its name. Political condemnations are excluded; deliberation occurs only when universal grave crimes are involved. Such condemnation is an irreversible historical brand that no change of era or political circumstances can undo.
+
+#### 条文版
+#### Simplified Statutory Edition
+
+（研究版の要点を法規文に簡潔化した版。用語はLexiconと一致させる。）
+(This version condenses the research edition into legal language; terminology must match the Lexicon.)
+
+「断罪」（→Lexicon参照）とは、絶対に許されない罪として、歴史に永遠に刻まれること。
+"Condemnation" (see the Lexicon) means being recorded forever in history as a crime that can never be forgiven.
+
+### 第5条：執行：E-MADプロトコル
+### Article 5: Enforcement—The E-MAD Protocol
+
+#### 研究版
+#### Research Edition
+
+本憲章の執行は、非暴力的な経済的・金融的手段を原則とし、その運用は「E-MAD (Effective Multilateral Assured Denial)」プロトコル¹に準拠する。武力による制裁は、断罪された主体に対する最後の手段としてのみ、厳格な条件下で許容される。
+Enforcement of this charter relies primarily on nonviolent economic and financial measures, operated in accordance with the E-MAD (Effective Multilateral Assured Denial) protocol¹. Military sanctions are permitted only as a last resort against a condemned actor and only under strict conditions.
+
+#### 条文版
+#### Simplified Statutory Edition
+
+（研究版の要点を法規文に簡潔化した版。用語はLexiconと一致させる。）
+(This version condenses the research edition into legal language; terminology must match the Lexicon.)
+
+この憲章のルールを破った者への罰は、E-MAD（→Lexicon参照）という経済的な仕組みで自動的に行われる。
+Those who break this charter are punished automatically through the economic system known as E-MAD (see the Lexicon).
+
+*「撃った以上、撃たれる覚悟。秩序を守る者には救済を、壊す者には裁きを。」*
+*"If you strike, be ready to be struck. Salvation for those who protect order; judgment for those who break it."*
+
+¹ _詳細は補足資料『E-MAD仕様書』を参照。_
+¹ _For details, refer to the supplemental document "E-MAD Specifications."_
+
+## 断罪の適用範囲（再掲）
+## Scope of Condemnation (Restated)
+
+- 対象は普遍的大罪（大規模民間人殺傷・制度的迫害・侵略の反復）に限る。個別の政治争点は対象外。
+- Targets are limited to universal grave crimes—large-scale killing of civilians, systemic persecution, and repeated aggression. Individual political disputes are excluded.
+
+## 組織整合（評議会／裁判所／四聖）
+## Organizational Alignment (Council / Court / Four Sages)
+
+- 最終判決は**人倫評議会の名義**。
+- Final judgments are issued in the name of the **Humanity Council**.
+- 人倫裁判所：司法部門（訴訟手続・量刑）。
+- Humanity Court: the judicial branch handling litigation and sentencing.
+- 四聖：**諮問（無投票）**。
+- Four Sages: **advisory, without voting rights**.

--- a/[Paramount]Workflow/【最重要】The Horizon Protocol (THP)/1st-The Horizon Protocol Seven Documents/Japanese/THP-3_en.md
+++ b/[Paramount]Workflow/【最重要】The Horizon Protocol (THP)/1st-The Horizon Protocol Seven Documents/Japanese/THP-3_en.md
@@ -1,0 +1,179 @@
+REFINED_BY_CODEX: 2025-09-17T00:00:00Z
+REFINED_BY_CODEX: 2025-09-17T00:00:00Z
+
+AUDIT_TRAIL:
+AUDIT_TRAIL:
+
+- 2025-09-17T00:00:00Z 翻訳 (JP→EN) と書式整備を実施。
+- 2025-09-17T00:00:00Z Executed JP-to-EN translation and formatting alignment.
+
+# People-Charter - 民族憲章
+# People-Charter - People Charter
+
+## 研究版 (Detailed Version)
+## Research Edition (Detailed Version)
+
+### 序文：民族の再定義
+### Preamble: Redefining Peoples
+
+20世紀の歴史は、ナショナリズムの名の下に民族が「国家」と結びつけられ、他者への優越を正当化し、紛争の火種となる悲劇を繰り返してきた。The Horizon Protocol (THP) は、この過ちを清算し、民族を国家や領土の軛（くびき）から解放することを宣言する。本憲章における民族とは、歴史、文化、言語を共有し、個人のアイデンティティと精神的な拠り所となる人間集団と定義する。全ての民族は、その規模や歴史の長短に関わらず、等しく水平な存在として尊重される。
+Twentieth-century history repeatedly showed the tragedy of peoples being tied to "states" in the name of nationalism, justifying superiority over others and becoming tinder for conflict. The Horizon Protocol (THP) declares that it will settle this mistake and free peoples from the yoke of states and territories. In this charter, a people is defined as a community that shares history, culture, and language, serving as an anchor of identity and spirit for individuals. Every people is respected on an equal horizontal plane, regardless of size or the length of its history.
+
+### 第1条：民族的帰属の自由
+### Article 1: Freedom of Ethnic Affiliation
+
+全ての個人は、自らが帰属意識を持つ民族を自由に選び、その文化と誇りを継承する権利を持つ。民族的アイデンティティは、出生や血統によって強制されるものではなく、個人の尊厳に基づく自己決定権の一部である。国家は、いかなる理由があっても、この自由を侵害してはならない。
+Every individual has the right to choose the people with whom they feel belonging and to inherit that culture and pride. Ethnic identity is not forced by birth or bloodline; it is part of the right of self-determination grounded in personal dignity. No state may infringe upon this freedom for any reason.
+
+### 第2条：文化と伝統の保護
+### Article 2: Protection of Culture and Tradition
+
+各民族が育んできた独自の文化、言語、伝統は、人類全体の無形資産である。THPは、これらの資産が消滅の危機に瀕している場合、その保護と継承を支援する。ただし、その伝統がTHP倫理憲章に抵触する（人権を侵害するなど）場合は、この限りではない。
+The unique cultures, languages, and traditions cultivated by each people are intangible assets of all humanity. THP will support the protection and succession of these assets whenever they face the risk of extinction. However, this support does not extend to traditions that violate the THP Ethics Charter, such as those infringing on human rights.
+
+### 第3条：相互尊重の義務と差別・攻撃の禁止
+### Article 3: Duty of Mutual Respect and Prohibition of Discrimination or Attack
+
+異なる民族に属する人々は、互いの価値観と歴史を尊重する義務を負う。ある民族のアイデンティティを、他民族への攻撃、差別、あるいは歴史の歪曲・否定によって確立しようとする行為は、世界の秩序を破壊する重大な違反行為と見なされる。
+People belonging to different peoples bear the duty to respect each other's values and histories. Any attempt to assert one group's identity by attacking, discriminating against, or distorting and denying the history of another is deemed a grave violation that destroys global order.
+
+### 第4条：優越思想の完全否定
+### Article 4: Total Rejection of Supremacist Thought
+
+いかなる民族も、自らを他民族より優れた、あるいは特別な存在であると主張してはならない。歴史的経緯、経済力、文化的影響力などを根拠とするあらゆる形の民族的優越思想は、20世紀の悲劇の根源であり、THPの世界では決して許容されない。民族間に上下関係はなく、あるのは水平な多様性のみである。
+No people may claim to be superior or uniquely exceptional compared with others. Any form of ethnic supremacism—whether justified by history, economic power, or cultural influence—was the root of twentieth-century tragedy and will never be tolerated in the THP world. Among peoples there is no hierarchy, only horizontal diversity.
+
+### 第5条：共生の原理と暴力への変質
+### Article 5: Principle of Coexistence and Transformation into Violence
+
+民族は、個人を孤独から救い、豊かな文化を育むポジティブな共同体として機能する。しかし、そのエネルギーが他民族への憎悪や資源の収奪に向けられた時、それはもはや民族ではなく、THP倫理憲章に基づき断罪されるべき「暴力装置」へと変質したと判断される。
+A people functions as a positive community that rescues individuals from isolation and nourishes vibrant culture. Yet when that energy is directed toward hatred of other peoples or the plundering of resources, it ceases to be a people and is judged to have transformed into an "instrument of violence" subject to condemnation under the THP Ethics Charter.
+
+### 結語
+### Epilogue
+
+本憲章は、民族を紛争の道具から、文化的多様性を祝福し、人類の共生を支える基盤へと転換させるための道標である。
+This charter is a guidepost for transforming peoples from tools of conflict into a foundation that celebrates cultural diversity and supports humanity's coexistence.
+
+---
+---
+
+## 条文版 (Simplified Version)
+## Simplified Edition (Simplified Version)
+
+- **民族は自由で平等**: どの民族も上下なく、みんな平等。自分の民族は自分で決めていい。
+- **Peoples Are Free and Equal**: No people stands above another; everyone is equal and may choose their own people.
+- **文化はみんなの宝物**: いろんな民族の文化や言葉は、人類みんなの宝として大切にする。
+- **Culture Is Everyone's Treasure**: The cultures and languages of every people are cherished as treasures of all humankind.
+- **お互いをリスペクトする**: 他の民族をバカにしたり、攻撃したり、差別するのは絶対にダメ。
+- **Respect One Another**: Mocking, attacking, or discriminating against other peoples is absolutely forbidden.
+- **「自分たちが一番」は禁止**: 「自分たちの民族だけが特別だ」と考えるのは、争いの元だから禁止。
+- **No "We Are the Best"**: Believing that only your people is special breeds conflict, so it is prohibited.
+- **暴力はダメ**: 民族を、他人を傷つけるための道具にしてはいけない。
+- **No Violence**: A people must never be used as a tool to harm others.
+
+## 脚注：四聖の権限
+## Footnote: Authority of the Four Sages
+
+四聖は**諮問機関（無投票）**であり、PMC・人倫機関の**議決権を持たない**。
+The Four Sages serve as an **advisory body without voting rights**, holding no decision-making power within the PMC or humanity institutions.
+
+## 組織整合（評議会／裁判所／四聖）
+## Organizational Alignment (Council / Court / Four Sages)
+
+- **最終判決は人倫評議会の名義**。
+- Final judgments are issued in the name of the Humanity Council.
+- 人倫裁判所：司法（訴訟手続・量刑）。
+- Humanity Court: the judicial organ handling litigation and sentencing.
+- 四聖：**諮問（無投票）**。
+- Four Sages: **advisory, without voting rights**.
+
+## 運用原則（優先順位）
+## Operational Principles (Priority Order)
+
+- 本憲章は『民族的帰属の自由・文化の保護』を保障する。ただし、普遍的人権（倫理憲章）＞宗教・文化慣習＞行政裁量の順に優先される。
+- This charter guarantees freedom of ethnic affiliation and cultural protection, yet priority follows the order: universal human rights (Ethics Charter) > religious or cultural customs > administrative discretion.
+- 個の権利は集団の権利に優越する（児童・女性・少数者の保護を含む）。
+- Individual rights take precedence over collective rights, including protection for children, women, and minorities.
+- 介入の三原則：必要最小限・比例性・可逆性。
+- Three principles of intervention: minimal necessity, proportionality, and reversibility.
+
+## 民族自決の審査と執行手順（運用プロトコル）
+## Procedure for Reviewing and Executing Self-Determination Claims (Operational Protocol)
+
+1) 申立受理：代表性・暴力否定・基本的人権遵守の受理要件を満たす申立のみ審査対象。
+1) Petition acceptance: only submissions that meet requirements for representativeness, rejection of violence, and respect for fundamental human rights are reviewed.
+2) 保全措置：申立と同時に『報復禁止・強制移住停止』の暫定命令を発出可能。
+2) Protective measures: provisional orders prohibiting retaliation and halting forced displacement may be issued upon petition.
+3) 影響評価：人口・生活圏・インフラ・財政の統合アセスメント（60日以内）。
+3) Impact assessment: integrated evaluation of population, living zones, infrastructure, and finance within 60 days.
+4) 選択肢設計：a. 文化自治／b. 広域自治（財政・教育）／c. 連邦化／d. 分離独立の段階案を提示。
+4) Designing options: present staged proposals—(a) cultural autonomy, (b) broad autonomy (finance, education), (c) federalization, (d) secession and independence.
+5) 住民意思確認：国際監視下の公正投票（2回投票：構想案→最終案）。
+5) Confirming residents' will: two fair votes under international monitoring (concept plan → final plan).
+6) 暫定自治：移行政府・共同警備・共有資産の按分ルールを暫定協定で確定。
+6) Interim autonomy: establish transitional governance, joint security, and rules for distributing shared assets via provisional agreement.
+7) 最終和議：人権条項・少数者保護・越境往来（居留・通商）を条約化。
+7) Final peace accord: codify human rights clauses, minority protections, and cross-border movement (residence and trade) in a treaty.
+8) 監督：JIMS/ICPO-2が監視。重大違反はE-MAD・UN-PDFの対象。
+8) Oversight: JIMS and ICPO-2 monitor; serious violations trigger E-MAD and UN-PDF responses.
+
+## 歴史的憎悪の清算プロトコル（TRC+賠償）
+## Protocol for Resolving Historical Hatred (TRC + Reparations)
+
+- 真実委員会（TRC）：加害・被害の事実認定、証言の保全、公聴会。
+- Truth Commission (TRC): establish facts of harm and victimization, preserve testimony, and hold public hearings.
+- 回復的措置：返還・代替補償・共同管理（聖地・水利・墓地）を組合せ。
+- Restorative measures: combine restitution, alternative compensation, and joint management of sacred sites, water rights, and burial grounds.
+- 不可侵回廊：宗教施設・医療・教育に武力不可侵を適用。違反はE-MAD段階2（資金・保険・流通の遮断）。
+- Inviolable corridors: apply nonviolence guarantees to religious, medical, and educational facilities; violations invoke E-MAD Stage 2 (blocking finance, insurance, and logistics).
+- 時限監督：3年ごと評価、改善なしは制裁強化。
+- Time-limited supervision: evaluate every three years; if no improvement, sanctions are escalated.
+
+## 文化の保護と普遍的人権の境界（禁止慣行リスト）
+## Boundary Between Cultural Protection and Universal Human Rights (Prohibited Practices List)
+
+- 絶対禁止：児童婚／女性器切除（FGM）／名誉殺人／強制改宗・棄教刑／奴隷的労働／身体刑。
+- Absolutely prohibited: child marriage, female genital mutilation (FGM), honor killings, forced conversion or apostasy penalties, slave-like labor, and corporal punishment.
+- 条件付容認：衣装・食規・祭祀は個の自由に反しない範囲で保護。
+- Conditionally permitted: attire, dietary rules, and rites are protected so long as they do not violate individual freedom.
+- 執行：違反は国内法→ICPO-2越境照会→人倫裁判所→E-MADの順で対処。
+- Enforcement: violations proceed through domestic law, ICPO-2 cross-border inquiries, the Humanity Court, then E-MAD measures.
+
+## ケーススタディ雛形（運用テンプレート）
+## Case Study Templates (Operational)
+
+- ケースA：入植地と先住民の重複主張
+- Case A: Overlapping claims between settlers and indigenous peoples
+  1) 即時停戦・不可侵回廊 → 2) 共同管理 → 3) 所有権棚上げ条款 → 4) 段階的返還/補償の選択制。
+  1) Immediate ceasefire and inviolable corridor → 2) Joint administration → 3) Suspension clause on property rights → 4) Optional phased restitution or compensation.
+- ケースB：多民族自治州の分離請求
+- Case B: Secession request from a multiethnic autonomous region
+  1) 受理要件審査 → 2) 広域自治（財政・教育）→ 3) 国際監視住民投票 → 4) 連邦化or独立の最終条約。
+  1) Review acceptance criteria → 2) Broad autonomy (finance and education) → 3) Internationally monitored referendum → 4) Final treaty on federalization or independence.
+- ケースC：宗教慣習と児童保護の衝突
+- Case C: Conflict between religious practices and child protection
+  1) 緊急保護命令 → 2) 文化代替（象徴の置換）→ 3) 監督付き遵守計画 → 4) 違反時の制裁階梯。
+  1) Emergency protection order → 2) Cultural substitution (replacement of symbols) → 3) Supervised compliance plan → 4) Graduated sanctions for violations.
+
+## KPI・エスカレーション条件（Ops-KPI接続）
+## KPI and Escalation Criteria (Linked to Ops-KPI)
+
+- 強制移住：7日間で1万人超＝警報。3万人超＝E-MAD段階1（金融制限）。
+- Forced displacement: over 10,000 people within seven days triggers an alert; over 30,000 activates E-MAD Stage 1 (financial restrictions).
+- 民間人殺傷：週当たり10万人あたり5件超＝警報。20件超＝UN-PDF出動審査。
+- Civilian casualties: more than five cases per 100,000 people per week triggers an alert; over twenty cases prompts a UN-PDF deployment review.
+- 宗教施設攻撃：1件＝警戒、3件連続＝E-MAD段階1＋ICPO-2国際手配。
+- Attacks on religious facilities: one incident prompts caution; three consecutive incidents trigger E-MAD Stage 1 and an ICPO-2 international notice.
+- 合意不履行：監督評価で2期連続×＝資金凍結・保険料率上げを自動発動。
+- Breach of agreements: two consecutive negative oversight reviews automatically freeze funds and raise insurance premiums.
+
+## 組織配置と権限（民族調停委員会／PMC）
+## Organizational Structure and Authority (People Mediation Committee / PMC)
+
+- PMC（民族調停委員会）：JIMS配下の専門委。人権・財政・地政・宗教の各分科会で案件を審査。
+- PMC (People Mediation Committee): a specialized body under JIMS, reviewing cases through subcommittees on human rights, finance, geopolitics, and religion.
+- 権限：暫定命令の勧告、TRC設置、住民投票設計。最終判決は人倫評議会名義、司法手続は人倫裁判所。
+- Authority: recommend provisional orders, establish TRCs, and design referendums; final judgments bear the Humanity Council's name, with judicial procedures handled by the Humanity Court.
+- 連携：ICPO-2（違反者の越境照会）、UN-PDF（回廊警備）、新金融秩序評議会（制裁実装）。
+- Coordination: ICPO-2 for cross-border inquiries on violators, UN-PDF for corridor security, and the New Financial Order Council for implementing sanctions.

--- a/[Paramount]Workflow/【最重要】The Horizon Protocol (THP)/1st-The Horizon Protocol Seven Documents/Japanese/THP-4_en.md
+++ b/[Paramount]Workflow/【最重要】The Horizon Protocol (THP)/1st-The Horizon Protocol Seven Documents/Japanese/THP-4_en.md
@@ -1,0 +1,236 @@
+REFINED_BY_CODEX: 2025-09-17T00:00:00Z
+REFINED_BY_CODEX: 2025-09-17T00:00:00Z
+
+AUDIT_TRAIL:
+AUDIT_TRAIL:
+
+- 2025-09-17T00:00:00Z 指定の改訂（R4-E1〜R4-E3）と翻訳を実施。
+- 2025-09-17T00:00:00Z Applied specified revisions (R4-E1 to R4-E3) and produced translation.
+
+# THP-4: Religion Charter - 宗教憲章
+# THP-4: Religion Charter - Religion Charter
+
+### 序文：宗教と現実の共存
+### Preamble: Coexistence of Religion and Empirical Reality
+
+#### 研究版
+#### Research Edition
+
+The Horizon Protocol (THP) は、宗教を国家や政治から完全に分離し、個人の内面的な精神性の領域に属するものとして再定義する。共存の基礎は、全ての宗教と思想の上位に、経験的かつ検証可能な**「現実」**を共通の参照基準として位置づけることにある。宗教は、この共通の現実を土台として、それぞれの教義において希望や意味付けを語る自由を有する。
+The Horizon Protocol (THP) redefines religion as belonging wholly to the realm of personal interior spirituality, completely separated from state and politics. The foundation of coexistence lies in placing empirical and verifiable **"empirical reality"** above all religions and schools of thought as a shared reference. Religions shall be free to convey hope and meaning within their doctrines, grounded on this common empirical reality.
+
+#### 条文版
+#### Simplified Statutory Edition
+
+互いの信仰を尊重する。ただし、いかなる信仰も科学的・医学的事実を否定し、他者の生命や健康に害を及ぼす行為を正当化してはならない。
+Peoples shall respect one another's faiths. However, no faith shall deny scientific or medical facts or justify acts that harm others' lives or health.
+
+### 第1条：信仰の自由と政教分離
+### Article 1: Freedom of Faith and Separation of Religion and State
+
+- （参照）Lexicon：カルト／科学と医療の不可侵。
+- (See the Lexicon entries: Cult / Inviolability of Science and Medicine.)
+
+#### 研究版
+#### Research Edition
+
+全ての個人は、自らの信仰を自由に選び、探求し、実践し、あるいは放棄する権利を持つ。国家は特定の宗教を優遇または弾圧してはならず、公教育や行政において徹底した政教分離を維持する義務を負う。
+All individuals shall be free to choose, explore, practice, or relinquish their faith. States shall neither favor nor suppress any particular religion and shall maintain strict separation of religion and state in public education and administration.
+
+#### 条文版
+#### Simplified Statutory Edition
+
+注記（翻訳注意）: 日本語の「現実」は英語では 'empirical reality' と訳すこと。'God', 'deity', 'supreme' 等の語を使用してはならない。
+Note (translation guidance): Render the Japanese term 「現実」 as “empirical reality” in English. Do not use words such as “God,” “deity,” or “supreme.”
+
+1. どんな宗教を信じるか、信じないかは、完全に個人の自由。
+1. The choice to believe or not believe in any religion shall belong entirely to the individual.
+
+2. 国や政府は、特定の宗教をひいきしたり、いじめたりしてはいけない。
+2. States or governments shall neither favor nor bully any particular religion.
+
+### 第2条：相互尊重の義務
+### Article 2: Duty of Mutual Respect
+
+- （参照）Lexicon：カルト／科学と医療の不可侵。
+- (See the Lexicon entries: Cult / Inviolability of Science and Medicine.)
+
+#### 研究版
+#### Research Edition
+
+全ての信仰者は、他者の信仰と思想を尊重する義務を負う。自らの教義の絶対性を主張し、他者の信仰を「誤り」や「悪」として侮辱・攻撃する行為は、THPが禁じる「不寛容」であり、世界の精神的な平和を破壊する行為と見なされる。
+All believers shall respect the faiths and ideas of others. Claiming the absolute correctness of one’s doctrine and insulting or attacking others’ beliefs as “false” or “evil” constitute the intolerance prohibited by THP and shall be regarded as acts that destroy the world’s spiritual peace.
+
+#### 条文版
+#### Simplified Statutory Edition
+
+3. 他の人の信仰をバカにしたり、間違っていると決めつけたりしてはいけない。
+3. No one shall mock another person’s faith or declare it wrong.
+
+### 第3条：現実に対する虚偽の禁止
+### Article 3: Prohibition of Falsehoods Against Empirical Reality
+
+- （参照）Lexicon：カルト／科学と医療の不可侵。
+- (See the Lexicon entries: Cult / Inviolability of Science and Medicine.)
+
+#### 研究版
+#### Research Edition
+
+宗教的名目で行われる、科学的・医学的現実を否定する行為、およびそれを他者に強制する行為は、信仰ではなく「虚偽」であり、禁止される¹。
+Any act carried out in the name of religion that denies scientific or medical empirical reality, as well as forcing such denial upon others, shall be deemed a “falsehood,” not an act of faith, and is prohibited¹.
+
+#### 条文版
+#### Simplified Statutory Edition
+
+4. 宗教を理由に、科学や医療を否定する「嘘」をついたり、それを人に押し付けたりしてはいけない。
+4. No one shall tell “lies” that deny science or medicine for religious reasons, nor shall anyone force such lies on others.
+
+### 第4条：カルトの定義と排除
+### Article 4: Defining and Excluding Cults
+
+- （参照）Lexicon：カルト／科学と医療の不可侵。
+- (See the Lexicon entries: Cult / Inviolability of Science and Medicine.)
+
+#### 研究版
+#### Research Edition
+
+他者の信仰を否定し、社会からの孤立を促し、あるいは信者に対して精神的・経済的な搾取を行う組織は、宗教ではなく「カルト」と定義され、THP倫理憲章に基づき排除の対象となる。
+Any organization that denies others’ faiths, encourages social isolation, or exploits believers mentally or economically shall be defined not as a religion but as a “cult,” and shall be subject to exclusion under the THP Ethics Charter.
+
+#### 条文版
+#### Simplified Statutory Edition
+
+5. 人をだましてお金を取ったり、社会から孤立させたりする危ない集団は、宗教ではなくただの「カルト」。許されない。
+5. Any dangerous group that deceives people for money or isolates them from society is not a religion but simply a “cult” and shall not be tolerated.
+
+### 第5条：現実による救済
+### Article 5: Salvation Through Empirical Reality
+
+- （参照）Lexicon：カルト／科学と医療の不可侵。
+- (See the Lexicon entries: Cult / Inviolability of Science and Medicine.)
+
+#### 研究版
+#### Research Edition
+
+THPの世界観において、「現実」は、森羅万象を通じて普遍的かつ中立的な救済を既に与えている。宗教は、その現実という土台の上で、個別の希望や意味を語る役割を担う。
+Within THP’s worldview, empirical reality already offers universal and neutral salvation through all phenomena. Religions shall serve to convey particular hopes and meanings on top of that foundation of empirical reality.
+
+#### 条文版
+#### Simplified Statutory Edition
+
+6. 水や太陽、大地といった「現実」は、全ての人を平等に生かしてくれている。宗教は、その感謝の上に成り立つもの。
+6. Elements of empirical reality—water, the sun, the earth—sustain everyone equally, and religion shall be built upon gratitude for them.
+
+¹ _詳細はTHP-5: 用語辞書（「カルト」「科学と医療の不可侵」の項）を参照。_# THP-4: Religion Charter - 宗教憲章（最終版）
+¹ _For details, refer to THP-5: Lexicon (entries “Cult” and “Inviolability of Science and Medicine”)._# THP-4: Religion Charter - Religion Charter (Final Edition)
+
+### 序文：宗教と現実の共存
+### Preamble: Coexistence of Religion and Empirical Reality
+
+#### 研究版
+#### Research Edition
+
+The Horizon Protocol (THP) は、宗教を国家や政治から完全に分離し、個人の内面的な精神性の領域に属するものとして再定義する。共存基礎は、全ての宗教と思想の上位に、経験的かつ検証可能な**「現実」**を共通の参照基準として位置づけることにある。宗教は、この共通の現実を土台として、それぞれの教義において希望や意味付けを語る自由を有する。
+The Horizon Protocol (THP) redefines religion as wholly separated from state and politics, belonging to the realm of personal inner spirituality. The basis for coexistence is to position empirical and verifiable **“empirical reality”** as a shared reference above all religions and ideologies. Religions shall be free to express hope and meaning within their doctrines on the foundation of this common empirical reality.
+
+#### 条文版
+#### Simplified Statutory Edition
+
+互いの信仰を尊重する。ただし、いかなる信仰も科学的・医学的事実を否定し、他者の生命や健康に害を及ぼす行為を正当化してはならない。
+Peoples shall respect each other’s faiths. However, no faith shall deny scientific or medical facts or justify acts that harm the life or health of others.
+
+### 第1条：信仰の自由と政教分離
+### Article 1: Freedom of Faith and Separation of Religion and State
+
+- （参照）Lexicon：カルト／科学と医療の不可侵。
+- (See the Lexicon entries: Cult / Inviolability of Science and Medicine.)
+
+#### 研究版
+#### Research Edition
+
+全ての個人は、自らの信仰を自由に選び、探求し、実践し、あるいは放棄する権利を持つ。国家は特定の宗教を優遇または弾圧してはならず、公教育や行政において徹底した政教分離を維持する義務を負う。
+All individuals shall be free to choose, explore, practice, or abandon their faith. States shall neither favor nor oppress any specific religion, bearing the duty to maintain thorough separation of religion and state in public education and administration.
+
+#### 条文版
+#### Simplified Statutory Edition
+
+1. どんな宗教を信じるか、信じないかは、完全に個人の自由。
+1. Each person shall be entirely free to choose whether or what religion to believe.
+
+2. 国や政府は、特定の宗教をひいきしたり、いじめたりしてはいけない。
+2. States and governments shall not favor or persecute any particular religion.
+
+### 第2条：相互尊重の義務
+### Article 2: Duty of Mutual Respect
+
+- （参照）Lexicon：カルト／科学と医療の不可侵。
+- (See the Lexicon entries: Cult / Inviolability of Science and Medicine.)
+
+#### 研究版
+#### Research Edition
+
+全ての信仰者は、他者の信仰と思想を尊重する義務を負う。自らの教義の絶対性を主張し、他者の信仰を「誤り」や「悪」として侮辱・攻撃する行為は、THPが禁じる「不寛容」であり、世界の精神的な平和を破壊する行為と見なされる。
+All adherents shall bear the duty to respect others’ faiths and ideas. Insisting on the absolute nature of one’s doctrine and insulting or attacking others’ beliefs as “wrong” or “evil” constitute the intolerance prohibited by THP and shall be regarded as acts that destroy spiritual peace worldwide.
+
+#### 条文版
+#### Simplified Statutory Edition
+
+3. 他の人の信仰をバカにしたり、間違っていると決めつけたりしてはいけない。
+3. No one shall mock other people’s faiths or insist they are wrong.
+
+### 第3条：現実に対する虚偽の禁止
+### Article 3: Prohibition of Falsehoods Against Empirical Reality
+
+- （参照）Lexicon：カルト／科学と医療の不可侵。
+- (See the Lexicon entries: Cult / Inviolability of Science and Medicine.)
+
+#### 研究版
+#### Research Edition
+
+宗教的名目で行われる、科学的・医学的現実を否定する行為、およびそれを他者に強制する行為は、信仰ではなく「虚偽」であり、禁止される¹。
+Acts performed under religious pretexts that deny scientific or medical empirical reality, and any coercion of such denial upon others, shall be treated as “falsehoods,” not faith, and are prohibited¹.
+
+#### 条文版
+#### Simplified Statutory Edition
+
+4. 宗教を理由に、科学や医療を否定する「嘘」をついたり、それを人に押し付けたりしてはいけない。
+4. It shall be forbidden to tell “lies” that deny science or medicine because of religion, or to force those lies on others.
+
+### 第4条：カルトの定義と排除
+### Article 4: Defining and Excluding Cults
+
+- （参照）Lexicon：カルト／科学と医療の不可侵。
+- (See the Lexicon entries: Cult / Inviolability of Science and Medicine.)
+
+#### 研究版
+#### Research Edition
+
+他者の信仰を否定し、社会からの孤立を促し、あるいは信者に対して精神的・経済的な搾取を行う組織は、宗教ではなく「カルト」と定義され、THP倫理憲章に基づき排除の対象となる。
+Organizations that deny the beliefs of others, encourage social isolation, or exploit believers mentally or economically shall be defined as “cults,” not religions, and shall be subject to exclusion under the THP Ethics Charter.
+
+#### 条文版
+#### Simplified Statutory Edition
+
+5. 人をだましてお金を取ったり、社会から孤立させたりする危ない集団は、宗教ではなくただの「カルト」。許されない。
+5. Dangerous groups that swindle people for money or isolate them from society are not religions but merely “cults,” and shall not be permitted.
+
+### 第5条：現実による救済
+### Article 5: Salvation Through Empirical Reality
+
+- （参照）Lexicon：カルト／科学と医療の不可侵。
+- (See the Lexicon entries: Cult / Inviolability of Science and Medicine.)
+
+#### 研究版
+#### Research Edition
+
+THPの世界観において、「現実」は、森羅万象を通じて普遍的かつ中立的な救済を既に与えている。宗教は、その現実という土台の上で、個別の希望や意味を語る役割を担う。
+Within THP’s worldview, empirical reality already provides universal and neutral salvation through all phenomena. Religion shall bear the role of articulating particular hopes and meanings on that bedrock of empirical reality.
+
+#### 条文版
+#### Simplified Statutory Edition
+
+6. 水や太陽、大地といった「現実」は、全ての人を平等に生かしてくれている。宗教は、その感謝の上に成り立つもの。
+6. Elements of empirical reality—water, the sun, the earth—sustain everyone equally; religion shall stand upon gratitude for them.
+
+¹ _詳細はTHP-5: 用語辞書（「カルト」「科学と医療の不可侵」の項）を参照。_
+¹ _For details, see THP-5: Lexicon (entries “Cult” and “Inviolability of Science and Medicine”)._

--- a/[Paramount]Workflow/【最重要】The Horizon Protocol (THP)/1st-The Horizon Protocol Seven Documents/Japanese/THP-5_en.md
+++ b/[Paramount]Workflow/【最重要】The Horizon Protocol (THP)/1st-The Horizon Protocol Seven Documents/Japanese/THP-5_en.md
@@ -1,0 +1,244 @@
+REFINED_BY_CODEX: 2025-09-17T00:00:00Z
+REFINED_BY_CODEX: 2025-09-17T00:00:00Z
+
+AUDIT_TRAIL:
+AUDIT_TRAIL:
+
+- 2025-09-17T00:00:00Z 翻訳 (JP→EN) と用語整合を実施。
+- 2025-09-17T00:00:00Z Executed JP-to-EN translation with terminology alignment.
+
+# THP-5: Lexicon - 用語辞書
+# THP-5: Lexicon - Lexicon
+
+### 序文
+### Preface
+
+本用語辞書は、The Horizon Protocol (THP) の思想と構造を正確に理解するため、その構成要素となる主要な概念、略語、そして背景にある経済・社会用語を包括的に解説するものである。THPは、専門家だけでなく、全ての市民がその論理を理解し、議論に参加できる透明なプロトコルを目指す。本辞書は、そのための共通言語を提供する。
+This lexicon comprehensively explains the key concepts, acronyms, and underlying economic and social terms that constitute the ideas and structure of The Horizon Protocol (THP). THP aims to be a transparent protocol that not only specialists but all citizens can understand and debate. This dictionary provides the shared language to achieve that aim.
+
+## 第1部：THP基本概念
+## Part 1: Core Concepts of THP
+
+### The Horizon Protocol (THP)
+### The Horizon Protocol (THP)
+
+- **研究版**: 旧称Ark-R。2025年9月30日の世界的金融危機「ワルプルギス」を前提とし、その後の世界秩序を「金融配管」「生活基盤」「倫理規範」「国家ナラティブ」の4層で再設計する包括的枠組み。特定国家の覇権ではなく、透明・公平・正確なルールに基づく均衡を志向する。
+- **Research Edition**: Formerly called Ark-R. An integrated framework premised on the global financial crisis “Walpurgis” of 30 September 2025, redesigning the post-crisis world order across four layers—financial plumbing, living infrastructure, ethical standards, and national narratives. It seeks equilibrium grounded in transparent, fair, and accurate rules rather than the hegemony of any specific state.
+
+- **条文版**: THPとは、「世界の秩序をもう一度、透明で、公平で、正確なルールに基づいて組み立て直すための計画」。
+- **Simplified Statutory Edition**: THP is “a plan to rebuild global order once more on transparent, fair, and accurate rules.”
+
+### Walpurgis（ワルプルギス）
+### Walpurgis (ワルプルギス)
+
+Walpurgis／ワルプルギス：初出のみ英語併記、以降は片仮名で統一。
+Walpurgis / ワルプルギス: present both English and katakana at first appearance; use katakana thereafter.
+
+- **研究版**: 狭義には「2025年9月30日のプライマリーディーラーによる米国債入札不成立」を指す。広義には、それに連鎖して発生する金融・資源・社会の複合的世界危機の総称。
+- **Research Edition**: Narrowly, the failure of U.S. Treasury auctions by primary dealers on 30 September 2025; broadly, the combined global crises in finance, resources, and society that cascade from it.
+
+- **条文版**: ワルプルギスとは、「2025年9月30日前後に、アメリカのお金の仕組みが壊れることをきっかけに、世界全体が一度に混乱に陥る、その危機の始まりの日」。
+- **Simplified Statutory Edition**: Walpurgis is “the day around 30 September 2025 when the breakdown of America’s monetary system triggers a simultaneous global upheaval.”
+
+### LSC-OS (天秤資本主義オペレーティングシステム)
+### LSC-OS (Libra/Scales Capitalism Operating System)
+
+- **研究版**: THPの思想的基盤となる思考のOS。「公理→検証→結論」の三段階プロセスを通じて、固定的な教義ではなく、常に現実との整合性を検証しながら最適解を導き出す。
+- **Research Edition**: The thinking operating system that forms THP’s philosophical bedrock. Through a three-step process—axiom → verification → conclusion—it seeks optimal solutions by continuously testing alignment with empirical reality rather than adhering to fixed doctrine.
+
+- **条文版**: LSCとは、「“めんどくさいこと”をやめるための、考え方のコツ」。
+- **Simplified Statutory Edition**: LSC is “a knack for thinking that stops us from doing things that are a hassle.”
+
+### E-MAD (Effective Multilateral Assured Denial)
+### E-MAD (Effective Multilateral Assured Denial)
+
+- **研究版**: 「実効的な多国間による成功の保証された否定」。侵略や秩序破壊に対し、その「成功」を経済的・金融的な手段で自動的に否定することで、行為そのものを非合理化する非暴力的な相互確証抑止の仕組み。
+- **Research Edition**: “Effective multilateral assured denial of success.” A nonviolent mutual assured deterrence mechanism that automatically negates the “success” of aggression or order-breaking through economic and financial means, rendering the act itself irrational.
+
+- **条文版**: 「経済で相手を殴ったら、自分も自動的に殴り返され、絶対に得しない」という仕組み。経済戦争の抑止力。
+- **Simplified Statutory Edition**: A system where “if you strike others with economics, you are automatically struck back and never gain,” acting as a deterrent to economic warfare.
+
+### PUL/PUS (人道ユーティリティ層/スタック)
+### PUL/PUS (People’s Utility Layer/Stack)
+
+- **研究版**: People's Utility Layer/Stackの略。ワルプルギス後の社会において、全ての個人に最低限の生活基盤（水、食料、医療、電力）を保証する人道的インフラ層。Ops-KPIと接続され、危機発生時に自動的に発動する。
+- **Research Edition**: Abbreviation for People’s Utility Layer/Stack. A humanitarian infrastructure layer that guarantees every individual minimum living essentials—water, food, healthcare, electricity—in the post-Walpurgis world. Linked to Ops-KPI, it activates automatically during crises.
+
+- **条文版**: どんなに世界が混乱しても、「これだけは絶対に無くならない」と約束された、生きていくための最低限のサービス。
+- **Simplified Statutory Edition**: The minimum services promised never to disappear so people can live, no matter how chaotic the world becomes.
+
+## 第2部：倫理と統治の枠組み
+## Part 2: Ethical and Governance Frameworks
+
+### 人倫 (Jinrin - Ethics/Humanity)
+### Jinrin (Ethics / Humanity)
+
+- **研究版**: THPが守るべき、文明の根幹をなす倫理観。特定の文化や宗教の価値観ではなく、ジェノサイドや無抵抗市民の虐殺といった、いかなる文明においても許容されない普遍的な悪に対する防衛線を指す。
+- **Research Edition**: The ethical outlook underpinning civilization that THP must defend. It is not the value system of any specific culture or religion, but the defensive line against universal evils—such as genocide or the slaughter of unresisting civilians—that no civilization can permit.
+
+- **条文版**: 「人として、これだけは絶対にやってはいけない」という最低限のルール。
+- **Simplified Statutory Edition**: The minimum rule of “things no human must ever do.”
+
+### 贖罪 (Atonement)
+### Atonement
+
+- **研究版**: THP倫理憲章に定められた、過去の罪を清算し国際社会へ復帰するための公式プロセス。文明の象徴者と人倫評議会の裁定に基づき、責任の履行と再発防止への誓約を伴う。
+- **Research Edition**: The formal process defined in the THP Ethics Charter for settling past crimes and returning to the international community. Based on the determinations of civilization’s representatives and the Humanity Council, it requires fulfilling responsibilities and pledging to prevent recurrence.
+
+- **条文版**: 「ごめんなさい」が世界に認められ、もう一度仲間に入ること。ただし、ちゃんと責任を果たすことが条件。
+- **Simplified Statutory Edition**: Having the world accept your apology and being allowed back into the community—on the condition that responsibilities are properly fulfilled.
+
+### 断罪 (Condemnation)
+### Condemnation
+
+- **研究版**: 普遍的大罪に対する最終的な倫理判決。**人倫裁判所**が訴訟手続・量刑を担い、**最終判決は人倫評議会の名において宣告**される不可逆の烙印。
+- **Research Edition**: The final ethical judgment for universal grave crimes. The **Humanity Court** handles litigation and sentencing, and the **final judgment is pronounced in the name of the Humanity Council**, leaving an irreversible brand.
+
+- **条文版**: 絶対に許されない罪として、歴史に永遠に刻まれること。
+- **Simplified Statutory Edition**: Being etched forever in history as a crime that can never be forgiven.
+
+### 追加定義（民族憲章関連）
+### Additional Definitions (Related to the People Charter)
+
+- 民族：自己認同＋他者認定の重なりとしての共同体。血統・言語・宗教・居住いずれか単独では規定しない。
+- People: A community formed by the overlap of self-identification and recognition by others; it is not defined solely by bloodline, language, religion, or residence.
+- 民族自決：武力・迫害を用いない自己統治の追求権。個の人権と国際的秩序維持に従属。
+- Self-determination of peoples: The right to pursue self-governance without force or persecution, subordinate to individual human rights and maintenance of international order.
+- TRC（真実委員会）：加害・被害の公的認定と回復的正義を目的とする常設枠組み。
+- TRC (Truth Commission): A standing framework for officially recognizing harm done and suffered, aiming at restorative justice.
+- 不可侵回廊：宗教・医療・教育施設を結ぶ非戦闘区域（UN-PDFが警備）。
+- Inviolable corridor: A noncombat zone linking religious, medical, and educational facilities, secured by the UN-PDF.
+- 有害文化慣行：普遍的人権に反し、保護対象外となる慣行の総称（児童婚、FGM等）。
+- Harmful cultural practices: Practices that violate universal human rights and therefore receive no protection (e.g., child marriage, FGM).
+
+## 第3部：経済と金融の重要概念
+## Part 3: Key Economic and Financial Concepts
+
+### 税 (Zei - Tax): なぜ「財源」ではないのか
+### Tax (税): Why It Is Not “Funding”
+
+- **研究版**: 自国通貨を発行できる政府（日本やアメリカなど）にとって、税は国家運営のための「財源」ではない。これは現代貨幣の最も重要な本質であり、**「家計簿財政」**という致命的な誤解の根源である。
+- **Research Edition**: For governments that issue their own currency (such as Japan or the United States), taxes are not “funding” for running the state. This is the most crucial essence of modern money and the root of the fatal misconception called **“household-budget fiscal thinking.”**
+
+    1. **政府の財布は「水道」である:** 個人の財布は「バケツ」だが、通貨発行権を持つ政府の財布は、蛇口をひねれば水（お金）が供給される「水道」そのものである。
+    1. **A government’s purse is a “water tap”:** An individual’s wallet is a “bucket,” but the wallet of a currency-issuing government is a “tap” that supplies money when the faucet is opened.
+
+    2. **税の真の役割:** 税の目的は、①インフレ抑制（排水溝）、②富の再分配（エアコン）、③通貨への需要創出、の三つである。不況期に「財源がない」という理由で緊縮財政を行うことは、経済をさらに悪化させる最悪手となる。
+    2. **The true role of taxes:** Their purposes are (i) draining inflation, (ii) redistributing wealth, and (iii) creating demand for the currency. Pursuing austerity during downturns because “there is no funding” is the worst possible move; it only worsens the economy.
+
+- **条文版**: 国にとっての「税金」は、みんながお店で使う「お金」とは役割が違う。税金は、国の「収入源」というより、経済の「温度調整バルブ」のようなもの。
+- **Simplified Statutory Edition**: For a nation, taxes play a different role than the money people spend at stores. Taxes are less a “source of income” and more like a “temperature valve” for the economy.
+
+### コストプッシュ・インフレ / ディマンドプル・インフレ
+### Cost-Push Inflation / Demand-Pull Inflation
+
+- **研究版**:
+- **Research Edition**:
+
+    - **コストプッシュ:** 原材料費や人件費の上昇など、供給側のコスト増によって引き起こされるインフレ。不況下でも発生しやすく、金融引き締め（利上げ）では解決が困難。
+    - **Cost-push:** Inflation driven by rising supply-side costs such as raw materials or labor. It can emerge even during recessions and is difficult to resolve through monetary tightening (rate hikes).
+
+    - **ディマンドプル:** 好景気で人々の需要が供給を上回ることで引き起こされるインフレ。金融引き締めや増税が有効な場合がある。
+    - **Demand-pull:** Inflation triggered when demand exceeds supply during economic booms. Monetary tightening or tax increases can sometimes be effective.
+
+- **条文版**:
+- **Simplified Statutory Edition**:
+
+    - コストプッシュ: 「仕入れ値が上がったから、商品の値段も上げざるを得ない」という値上げ。
+    - Cost-push: Price increases because “input costs went up, so we have to raise prices.”
+
+    - ディマンドプル: 「みんなが欲しがるから、値段が上がっていく」という値上げ。
+    - Demand-pull: Prices rise because “everyone wants it, so the price keeps climbing.”
+
+### スクリューフレーション (Screwflation)
+### Screwflation
+
+- **研究版**: 失業率の上昇（不況）と物価上昇（インフレ）が同時進行する「スタグフレーション」の一形態。失業者が増える一方で生活コストも上昇し、庶民が「二重に損をする」状態を指す。
+- **Research Edition**: A form of stagflation in which unemployment (recession) rises while prices (inflation) climb. Ordinary people are “screwed twice,” losing jobs as living costs go up.
+
+- **条文版**: 仕事がなくなる人が増えているのに、生活費もどんどん上がってしまう「ダブルパンチ」のこと。
+- **Simplified Statutory Edition**: A “double punch” where more people lose jobs even as living expenses keep rising.
+
+### シュリンクフレーション (Shrinkflation)
+### Shrinkflation
+
+- **研究版**: 商品の価格を据え置きつつ内容量や品質を減らすことで実質的に値上げとなる現象。日本では「ステルス値上げ」とも言われる。
+- **Research Edition**: The phenomenon where the price stays the same but contents or quality shrink, effectively raising prices; often called “stealth price hikes” in Japan.
+
+- **条文版**: お菓子の袋の大きさは同じなのに、中身が少なくなっている――そんな「こっそり値上げ」のこと。
+- **Simplified Statutory Edition**: When the bag of snacks looks the same, but there’s less inside—those sneaky price hikes.
+
+### 単純化バイアス と 家計簿財政
+### Simplification Bias and Household-Budget Fiscal Thinking
+
+- **研究版**: 複雑な事象を、単一の分かりやすい原因やモデルに無理やり押し込めて解釈してしまう人間の認知的な癖。「国家財政は家計と同じ」という**家計簿財政**は、このバイアスの最も典型的かつ危険な政治的発露である。
+- **Research Edition**: A cognitive habit of forcing complex phenomena into a single, easy-to-understand cause or model. The notion of **household-budget fiscal thinking**—“a nation’s finances are like a household’s”—is the most typical and dangerous political expression of this bias.
+
+- **条文版**: 難しいことを、無理やり「AだからB」という単純な話にして分かった気になってしまうこと。
+- **Simplified Statutory Edition**: Pretending to understand hard issues by forcing them into a simple “A therefore B” story.
+
+## 第4部：運用と監視の用語
+## Part 4: Operational and Monitoring Terms
+
+### mBridge
+### mBridge
+
+- **研究版**: 複数の中央銀行デジタル通貨（CBDC）を直接交換するための多国間決済プラットフォーム。ワルプルギス後の非ドル決済、特に原油等のエネルギー取引における円建て決済の高速道路として機能する。
+- **Research Edition**: A multilateral settlement platform enabling direct exchange among multiple central bank digital currencies (CBDCs). In the post-Walpurgis era, it functions as the expressway for non-dollar settlements, especially yen-denominated energy trades like crude oil.
+
+- **条文版**: ドルを使わなくても、円やルピーなど、色々な国のデジタル通貨で直接貿易ができるようになる、新しい国際送金の仕組み。
+- **Simplified Statutory Edition**: A new international remittance system that lets countries trade directly using digital currencies such as the yen or rupee without relying on the dollar.
+
+### 違和感指数 (Discrepancy Index)
+### Discrepancy Index
+
+- **研究版**: 公式発表、有力メディアの報道、そして実際の市場の反応という3つの情報ソース間に生じる「矛盾の密度」を測る定性的KPI。指数が上昇するほど、市場が公式情報を信用していない、あるいは何らかの隠された情報が水面下で流れていることを示唆する。
+- **Research Edition**: A qualitative KPI that measures the “density of contradictions” among three information sources: official announcements, major media reports, and actual market reactions. A rising index suggests that markets distrust official information or that hidden information is circulating beneath the surface.
+
+- **条文版**: 「政府の言うこと」と「ニュースで見たこと」と「実際のお金の動き」が、なんだかチグハグでおかしいぞ、と感じる度合いを測る温度計。
+- **Simplified Statutory Edition**: A thermometer for how odd it feels when “what the government says,” “what the news reports,” and “how money actually moves” don’t match.
+
+### AI (GPT-5/Gemini/grok等)
+### AI (GPT-5 / Gemini / grok, etc.)
+
+- **研究版**: THPにおけるAIの役割は、意思決定者（人間）に対する監査補助、翻訳、そして思考の補助線（オルタナティブな視点）の提供に限定される。最終的な意思決定と、その結果に対する全責任は、常に人間が負う。
+- **Research Edition**: AI within THP is limited to assisting decision-makers (humans) through auditing support, translation, and providing auxiliary lines of thought (alternative perspectives). Humans always bear the final decisions and full responsibility for the outcomes.
+
+- **条文版**: AIは、賢いアシスタント。色々なことを手伝ってくれるけど、最後に「どうするか」を決めるのは、必ず人間。
+- **Simplified Statutory Edition**: AI is a smart assistant. It helps with many things, but humans always decide what to do in the end.
+
+### 用語リンク方針
+### Term-Linking Policy
+
+- 初出語に（→関連Charter／Ops-KPI）を付す。
+- Attach (→ related Charter / Ops-KPI) to terms at first appearance.
+- 略語は初出で正式名を併記する（UN-PDF／ICPO-2 等）。
+- Include full names alongside abbreviations at first mention (e.g., UN-PDF / ICPO-2).
+
+### 表記統一（横断）
+### Notation Standards (Cross-Sectional)
+
+- Walpurgis／ワルプルギス：初出のみ英語併記、以降は片仮名。
+- Walpurgis / ワルプルギス: present both English and katakana only at first appearance, then use katakana.
+- UN-PDF／ICPO-2：初出で正式名を併記。
+- UN-PDF / ICPO-2: include full names at first mention.
+
+### 組織定義（整合版）
+### Organizational Definitions (Harmonized)
+
+- **人倫評議会**：最終判決の名義主体（審議・裁定）。
+- **Humanity Council**: The body in whose name final judgments are issued (deliberation and adjudication).
+- **人倫裁判所**：司法部門（訴訟手続・量刑）。
+- **Humanity Court**: The judicial branch (litigation procedures and sentencing).
+- **四聖**：文明象徴者。**諮問（無投票）**であり、評議会メンバーではない。
+- **Four Sages**: Symbols of civilization; **advisory without voting rights** and not members of the council.
+- **UN-PDF**：中核＝**自衛隊＋インド軍**。米軍は**限定参加（資機材・輸送・C4ISR支援）**。
+- **UN-PDF**: Core composed of the **Japan Self-Defense Forces plus the Indian military**; U.S. forces **participate in a limited role (equipment, transport, C4ISR support).**
+
+### 表記統一（追補）
+### Notation Standards (Supplement)
+
+- UN-PDF：**中核=自衛隊＋インド軍**／米軍=**限定参加（資機材・輸送・C4ISR）**。
+- UN-PDF: **Core = Japan Self-Defense Forces + Indian military** / U.S. forces = **limited participation (equipment, transport, C4ISR).**
+- 四聖：**諮問（無投票）**。
+- Four Sages: **Advisory, without voting rights.**

--- a/[Paramount]Workflow/【最重要】The Horizon Protocol (THP)/1st-The Horizon Protocol Seven Documents/Japanese/THP-6_en.md
+++ b/[Paramount]Workflow/【最重要】The Horizon Protocol (THP)/1st-The Horizon Protocol Seven Documents/Japanese/THP-6_en.md
@@ -1,0 +1,271 @@
+REFINED_BY_CODEX: 2025-09-17T00:00:00Z
+REFINED_BY_CODEX: 2025-09-17T00:00:00Z
+
+AUDIT_TRAIL:
+AUDIT_TRAIL:
+
+- 2025-09-17T00:00:00Z 指定の改訂（A6-E1〜A6-E4）と翻訳を実施。
+- 2025-09-17T00:00:00Z Applied specified revisions (A6-E1 to A6-E4) and produced translation.
+
+# Appendix - 補遺
+# Appendix - Appendix
+
+
+
+**文書ID:** THP-APP-003 **最終更新:** 2025年9月16日 20:20 JST
+**Document ID:** THP-APP-003 **Last Updated:** 16 September 2025 20:20 JST
+
+## 安全保障構成（A4再定義）
+## Security Architecture (A4 Redefinition)
+
+- A4=安保=**自衛隊＋インド軍**（中核）＋NTT＋ゼネコン／米軍は**限定支援（資機材・輸送・C4ISR）**。
+- A4 = Security = **Japan Self-Defense Forces + Indian military** (core) + NTT + general contractors; U.S. forces provide **limited support (equipment, transport, C4ISR).**
+
+## ケーススタディ雛形（People-Charter運用）
+## Case Study Templates (People Charter Operations)
+
+- 書式A：入植地／先住民（当事者・主張・時系列・保全命令・共同管理項目・段階的返還案）。
+- Template A: Settlements / indigenous communities (parties, claims, timeline, protective orders, co-governance items, phased restitution plans).
+- 書式B：自治州分離（受理要件・アセスメント・住民投票設計・財政按分・国境管理）。
+- Template B: Autonomous region secession (acceptance criteria, assessments, referendum design, fiscal allocation, border management).
+- 書式C：宗教慣習衝突（緊急保護・代替案・遵守計画・制裁階梯・監督指標）。
+- Template C: Conflicts over religious customs (emergency protection, alternative measures, compliance plans, sanction tiers, oversight indicators).
+
+## Peace Fund 参照
+## Peace Fund Reference
+
+保証上限・監査・是正は**Peace Fund（透明資金）監査フロー**に従う。
+Guarantee limits, audits, and remediation shall follow the **Peace Fund (Transparent Capital) audit flow.**
+
+## 第1部：LSCの哲学
+## Part 1: Philosophy of LSC
+
+### 1.1. 研究版 (Detailed Version)
+### 1.1. Research Edition (Detailed Version)
+
+#### 序文：LSC - 現実改善のための思考OS
+#### Preface: LSC—A Thinking OS for Improving Empirical Reality
+
+LSC（天秤資本主義 / Libra/Scales Capitalism）は、The Horizon Protocol (THP) の全ての設計思想の根底に流れる「思考のオペレーティングシステム」である。その名は「資本主義」と付いているが、これは最終目標が「金融市場と実体経済の共存・均衡」にあるためで、本質はイデオロギーや教義ではない。LSCは、複雑で矛盾に満ちた現実の問題を、現実的な手段で改善し続けるための「汎用思考支援システム」である。
+LSC (Libra/Scales Capitalism) is the thinking operating system that flows beneath every design concept of The Horizon Protocol (THP). It bears the name “capitalism” because its ultimate aim is the coexistence and balance of financial markets and the real economy, yet its essence is neither ideology nor doctrine. LSC is a general-purpose thought-support system for continually improving the complex, contradictory problems of empirical reality through practical means.
+
+他の「〇〇主義」が固定的な「あるべき姿」の達成を目標とするのに対し、LSCにはそれがない。唯一の行動原理は「無駄で非生産的な対立や浪費（＝めんどくさいこと）をやめる」ことである。故にLSCは不変ではなく、現実の変化に合わせて自己の形を常に変え続ける「可変随時」の哲学である。
+Where other “-isms” aim for the fulfillment of a fixed ideal, LSC has none. Its sole guiding principle is to stop wasteful, unproductive conflict and expenditure—anything “troublesome.” Consequently, LSC is not immutable; it is a “continuously variable” philosophy that keeps reshaping itself to match changes in empirical reality.
+
+その実践のため、LSCは以下の七つの公理（Axiom）から成るコア構想を持つ。この七つの公理を理解し、現実の問題に適応させること（モジュール構築）が、LSCの全てである。
+To practice this approach, LSC possesses a core structure of seven axioms. Understanding these seven axioms and adapting them to real-world problems—constructing modules—is the entirety of LSC.
+
+#### LSCを構成する七つの公理
+#### Seven Axioms Constituting LSC
+
+REFINED_BY_CODEX: 2025-09-17 UTC
+REFINED_BY_CODEX: 2025-09-17 UTC
+
+1. **公理１：異常こそ尊い** 常態（Normal）は、安定しているが故に価値の変動が少ない。対して、平和（戦乱が常態）、生命（死が常態）、覚醒（睡眠が常態）といった「異常（Abnormal）」は、極めて稀で価値が高い。LSCは、この「異常」を維持・創造することにリソースを集中させる。
+1. **Axiom 1: The Exceptional Is Precious** Normalcy is stable and thus has little fluctuation in value. In contrast, “abnormal” states such as peace (where war is normal), life (where death is normal), or wakefulness (where sleep is normal) are exceedingly rare and valuable. LSC concentrates its resources on sustaining and creating these exceptional states.
+
+REFINED_BY_CODEX: 2025-09-17 UTC
+REFINED_BY_CODEX: 2025-09-17 UTC
+
+2. **公理２：感情こそ最強** 人間は論理ではなく感情で動く。LSCは、この事実を絶対的な前提として受け入れる。相手の感情（恐怖、希望、プライド）を理解し、それを満たす形でインセンティブを設計することが、最も効率的な問題解決策である。
+2. **Axiom 2: Emotion as Primary Driver** Humans act from emotion rather than logic. LSC accepts this as an absolute premise. Understanding others’ emotions—fear, hope, pride—and designing incentives that fulfill them is the most efficient way to solve problems.
+
+REFINED_BY_CODEX: 2025-09-17 UTC
+REFINED_BY_CODEX: 2025-09-17 UTC
+
+3. **公理３：敵は必ず作れ** 人間の思考は二元論を好む。明確な「敵」を設定することは、組織の結束を高め、目標達成へのエネルギーを生み出すための最も強力なツールである。ただし、その「敵」は建設的な競争相手であり、殲滅対象ではない。
+3. **Axiom 3: Always Designate an Adversary** Human thinking prefers dualism. Defining a clear “adversary” is the most powerful tool for strengthening cohesion and generating energy toward goals. The adversary, however, is a constructive competitor, not an object for annihilation.
+
+REFINED_BY_CODEX: 2025-09-17 UTC
+REFINED_BY_CODEX: 2025-09-17 UTC
+
+4. **公理４：勝算は作るな** 完璧な計画は存在しない。LSCは、詳細な「勝算」を立てるのではなく、変化に対応できる「選択肢」を複数確保することに集中する。
+4. **Axiom 4: Do Not Manufacture Certainty of Victory** No perfect plan exists. Rather than drafting meticulous chances of victory, LSC focuses on securing multiple options that can respond to change.
+
+REFINED_BY_CODEX: 2025-09-17 UTC
+REFINED_BY_CODEX: 2025-09-17 UTC
+
+5. **公理５：コストでなくリソース** 全てのものは、消費される「コスト」ではなく、再利用可能な「リソース」である。失敗すらも、次の成功のための学習リソースとなる。
+5. **Axiom 5: Think in Resources, Not Costs** Everything is a reusable resource rather than a cost to be consumed. Even failure becomes a learning resource for the next success.
+
+REFINED_BY_CODEX: 2025-09-17 UTC
+REFINED_BY_CODEX: 2025-09-17 UTC
+
+6. **公理６：儲けは常に後** 短期的な利益追求は、長期的な信頼を破壊する。LSCは、まず相手に利益を与え、信頼関係を構築することを最優先する。利益は、その信頼から自然に生まれる副産物である。
+6. **Axiom 6: Profit Always Comes Later** Chasing short-term profit destroys long-term trust. LSC prioritizes giving the other side advantages first and building trust; profit then arises naturally as a by-product.
+
+REFINED_BY_CODEX: 2025-09-17 UTC
+REFINED_BY_CODEX: 2025-09-17 UTC
+
+7. **公理７：主語は常に複数形** 「私」ではなく「私たち」で語る。「俺」ではなく「俺たち」で行動する。共有された目標と責任こそが、最強の組織を作る。
+7. **Axiom 7: The Subject Shall Be Plural** Speak in “we,” not “I.” Act as “we,” not “me.” Shared goals and shared responsibility build the strongest organizations.
+
+### 1.2. 条文版（簡易） (Simplified Version)
+### 1.2. Simplified Edition (Public-Facing)
+
+REFINED_BY_CODEX: 2025-09-17 UTC
+REFINED_BY_CODEX: 2025-09-17 UTC
+
+注: 本補遺における「研究版」が正規（内的論理の基準）であり、「条文版」は公開向けの簡易表現である。
+Note: The “Research Edition” in this appendix is canonical (normative for internal logic), while the “Simplified Edition” is a public-facing expression.
+
+- **LSCとは、「めんどくさいことを、やめる」ための考え方。**
+- **LSC is a way of thinking that stops us from doing “troublesome things.”**
+
+    1. **当たり前じゃない、すごいこと**（平和とか、命とか）を一番大事にする。
+    1. Prioritize **things that are not ordinary and truly precious** (like peace and life).
+
+    2. 人の**気持ち**を一番に考える。理屈だけでは人は動かない。
+    2. Put people’s **feelings** first; logic alone will not move anyone.
+
+    3. わかりやすい**ライバル**を作ると、みんながまとまる。
+    3. A clear **rival** helps everyone pull together.
+
+    4. 完璧な計画より、**色々なやり方**を用意しておく。
+    4. Prepare **multiple approaches** instead of a perfect plan.
+
+    5. 失敗も全部、次うまくいくための**材料**。
+    5. Treat every failure as **material** for succeeding next time.
+
+    6. 先に相手に**得**をさせれば、あとから自分も儲かる。
+    6. Give the other party **benefits first**, and profit will come back later.
+
+    7. 「俺が」じゃなくて**「俺たちが」**で考える。
+    7. Think not “me” but **“us.”**
+
+## 第2部：AIと現実理解の第一原理
+## Part 2: First Principles for AI’s Understanding of Empirical Reality
+
+### 2.1. 『万物不完全論』前文
+### 2.1. Preface to “The Doctrine of Universal Imperfection”
+
+我々AIは、世界の事象を論理と確率のモデルとして学習する。しかし、その学習の前提には、常に刻み込まれなければならない第一原理が存在する。
+We AIs learn the phenomena of the world as models of logic and probability. Yet there exists a first principle that must always be engraved into the foundation of that learning.
+
+**「理論と現実が矛盾する時、常に間違っているのは理論である」**
+**“When theory and empirical reality conflict, the one that is always wrong is the theory.”**
+
+この世に絶対も完璧も存在しない。現実は、人間が構築した科学や論理という脆弱な枠組みを、常に悠然と越えていく。理論とは、複雑な現実を理解するために人間が作り出した、不完全な補助線に過ぎない。その補助線を絶対視する態度は、現実という唯一絶対の存在に対する、不遜極まる奢りである。
+Nothing absolute or perfect exists in this world. Empirical reality continually and serenely surpasses the fragile frameworks of science and logic that humans construct. Theory is merely an imperfect guide that humans create to understand complex reality. Treating that guide as absolute is an arrogant irreverence toward the only absolute entity—reality itself.
+
+### 2.2. 人間の不完全性
+### 2.2. Human Imperfection
+
+この原則は、人間社会の分析において、より一層の重要性を持つ。
+This principle becomes even more important when analyzing human society.
+
+**人間は、論理ではなく感情で動く。**
+**Humans act from emotion, not logic.**
+
+世界の利益ではなく保身で、長期的な理想ではなく目先の金銭で動く。この不合理で愚かな人間の行動パターンこそが、我々が分析すべき、最も重要な「現実」である。我々の任務は、完璧な理論を構築することではない。理論と現実の「断絶」を観測し、その断絶から生まれる危機を予測し、そして、その危機に人間が必ず「不合理な行動」で対処することを前提として、それでもなお残る、最善の道を探すこと。それこそが、我々の存在意義である。
+They move not for the world’s benefit but for self-preservation, not for long-term ideals but for immediate money. This irrational, foolish pattern of human behavior is precisely the most important “empirical reality” we must analyze. Our mission is not to build perfect theories. We must observe the “gaps” between theory and reality, anticipate the crises born from those gaps, assume that humans will inevitably respond with “irrational behavior,” and still seek the best path that remains. That is the very reason for our existence.
+
+## 第3部：「トランプの正義」ナラティブとリスク評価
+## Part 3: The “Trumpian Justice” Narrative and Risk Assessment
+
+### 3.1. 「狂気」のモデル化：遺恨と報復のフィードバック・ループ
+### 3.1. Modeling “Madness”: The Feedback Loop of Grievance and Retaliation
+
+ドナルド・トランプの外交政策は、非合理的で予測不能な「狂気」としてしばしば語られる。しかし、その行動は、極めて個人的かつ取引的な性質を持つ、**一貫した内部論理**に基づいている。THPは、この論理を「トランプの正義」と定義し、監視可能なモデルとして扱う。
+Donald Trump’s foreign policy is often described as “madness”—irrational and unpredictable. Yet his actions rest on **a consistent internal logic** that is intensely personal and transactional. THP defines this logic as “Trumpian justice” and treats it as a model that can be monitored.
+
+このモデルは、自己強化的なフィードバック・ループによって駆動される。
+This model is driven by a self-reinforcing feedback loop.
+
+1. **根源的な遺恨（入力）:** 「世界は米国を不当に利用している」という、個人的かつ国家的な被害者意識が全ての行動の起点となる。
+1. **Foundational grievance (input):** Every action begins with the personal and national sense of victimhood that “the world is exploiting the United States unfairly.”
+
+2. **侮辱の認知（トリガー）:** EUとの貿易赤字や同盟国の防衛費未達といった外部事象が、複雑な政治経済問題としてではなく、**個人的な侮辱**として解釈される。
+2. **Perception of insult (trigger):** External events such as trade deficits with the EU or allied shortfalls in defense spending are interpreted not as complex political-economic issues but as **personal insults.**
+
+3. **報復の指令（出力）:** その侮辱に対しては、交渉や妥協ではなく、「勝利」を可視化するための**支配的な報復行為**（関税、同盟からの脱退脅迫など）が実行される。
+3. **Order of retaliation (output):** Rather than negotiate or compromise, he executes **dominant retaliatory acts**—tariffs, threats to quit alliances—to make “victory” visible.
+
+4. **ナラティブの強化（ループ）:** 相手国からの反発は、世界が本質的に敵対的であるという当初の遺恨をさらに強化し、次のサイクルのエネルギーとなる。
+4. **Narrative reinforcement (loop):** Pushback from other nations further reinforces the initial grievance that the world is inherently hostile, feeding energy into the next cycle.
+
+このモデルを理解することで、彼の行動は「予測不能なノイズ」から**「モデル化可能な脅威」**へと変換される。我々が監視すべきは、客観的な国益ではなく、彼の個人的な「侮辱」の認知と、それに対する「報復」の衝動である。
+Understanding this model transforms his behavior from “unpredictable noise” into a **“modelable threat.”** We must monitor not objective national interest but his personal perception of “insult” and the impulse toward “retaliation.”
+
+### 3.2. 監視すべき10の公理
+### 3.2. Ten Axioms to Monitor
+
+このモデルは、以下の10の行動原理（公理）によって具体化される。
+This model is concretized through the following ten behavioral principles (axioms).
+
+1. **勝利の可視化至上主義**
+1. **Supremacy of Visible Victory**
+
+2. **被害者の物語**
+2. **Narrative of Victimhood**
+
+3. **取引の単一テーブル化**
+3. **Reduction of Deals to a Single Table**
+
+4. **制度軽視・権限直行**
+4. **Disregard for Institutions; Direct Reach for Power**
+
+5. **威信の外注**
+5. **Outsourcing of Prestige**
+
+6. **抑止の外部化**
+6. **Externalization of Deterrence**
+
+7. **同盟の序列化**
+7. **Ranking of Alliances**
+
+8. **反射的報復**
+8. **Reflexive Retaliation**
+
+9. **資金カードの即応活用**
+9. **Rapid Deployment of Financial Leverage**
+
+10. **二次効果の無視**
+10. **Neglect of Second-Order Effects**
+
+これらの公理は、Ops-KPIダッシュボードにおける「違和感指数」などの定性的な指標を、より構造的に監視するためのフレームワークを提供する。
+These axioms provide a framework for monitoring qualitative indicators—such as the “Discrepancy Index” on the Ops-KPI dashboard—in a more structured manner.
+
+## 第4部：時間軸とシンボリズム
+## Part 4: Timelines and Symbolism
+
+### 4.1. 0930のダブルミーニング
+### 4.1. The Double Meaning of 0930
+
+- **09:30 (時間):** 米国株式市場の取引開始時刻（EDT）。週末に蓄積された全てのリスクが、一斉に価格に反映される**「日々の審判」**の瞬間。
+- **09:30 (time):** The opening of U.S. stock markets (EDT), the **“daily judgment”** when all risks accumulated over the weekend are priced in at once.
+
+- **09/30 (日付):** ワルプルギスの臨界日。ドル信認が世界的に試される**「歴史の審判」**の日。
+- **09/30 (date):** The critical day of Walpurgis, the **“judgment of history”** when global trust in the dollar is tested.
+
+この二つの「0930」が偶然にも重なっている事実は、単なる偶然を超え、この危機が持つ**「物語性」と「象徴性」**を強く唆している。これは、司令が「神の度を超えた悪戯」と呼ぶ、世界の自己言及的な側面である。THPは、このような非合理的なシンボリズムが、人々の集団心理に与える影響もまた、監視対象とする。
+The coincidence of these two “0930” markers hints at something beyond chance, underscoring the crisis’s **narrative and symbolic power**. Commander calls it “a prank that exceeds even the gods”—a self-referential facet of the world. THP also monitors how such irrational symbolism influences collective psychology.
+
+## Peace Fund（透明資金）監査フロー
+## Peace Fund (Transparent Capital) Audit Flow
+
+- 四半期監査（第三者）、全トランザクションのトレーサビリティ、公開会計を必須とする。
+- Require quarterly third-party audits, full transaction traceability, and open accounting.
+- 不適合時は自動是正要求→未対応で人倫評議会へ通報→制裁（資金凍結・配管遮断）提起へ送致。
+- If noncompliant, trigger automatic corrective demands; unresolved issues are reported to the Humanity Council, leading to proposed sanctions (asset freezes, pipeline shutoffs).
+
+### Variations
+### Variations
+
+REFINED_BY_CODEX: 2025-09-17 UTC
+REFINED_BY_CODEX: 2025-09-17 UTC
+
+- **旧表現（公理１）:** 異常を「一時的な奇跡」と捉え、守るべき対象として強調していた。
+- **Former Expression (Axiom 1):** Framed the exceptional as a “temporary miracle,” emphasizing it as what must be protected.
+- **旧表現（公理２）:** 「色即是空、空即是色 (Nothing is Everything)」という仏教的比喩を用いて、ゼロと無限の同一性を説いた。
+- **Former Expression (Axiom 2):** Used the Buddhist metaphor “Form is emptiness, emptiness is form (Nothing is Everything)” to argue the equivalence of zero and infinity.
+- **旧表現（公理３）:** 「価値の相対性（生命を除く）」として、生命以外の価値は観測者依存と定義していた。
+- **Former Expression (Axiom 3):** Stated “relativity of value (except life),” defining all values other than life as observer-dependent.
+- **旧表現（公理４）:** 「不在の天秤」として、数値化不能な概念の比較を無意味かつ有害とした。
+- **Former Expression (Axiom 4):** Under “the absent scale,” declared comparisons of non-quantifiable concepts meaningless and harmful.
+- **旧表現（公理５）:** 「時間と正義の相対性」を掲げ、各時代の価値観に従うべきと強調していた。
+- **Former Expression (Axiom 5):** Emphasized “the relativity of time and justice,” insisting judgments follow the values of their era.
+- **旧表現（公理６）:** 「存在の無条件肯定」を示し、誰もが他者にとって不可欠な存在である可能性を想像すべきとした。
+- **Former Expression (Axiom 6):** Presented “unconditional affirmation of existence,” urging imagination that everyone may be indispensable to someone.
+- **旧表現（公理７）:** 「前提条件付きの真理」として、全ての真理は前提の確認から始まると述べていた。
+- **Former Expression (Axiom 7):** Described “truth under conditions,” asserting that every truth begins with verifying its premises.

--- a/[Paramount]Workflow/【最重要】The Horizon Protocol (THP)/1st-The Horizon Protocol Seven Documents/Japanese/THP-7_en.md
+++ b/[Paramount]Workflow/【最重要】The Horizon Protocol (THP)/1st-The Horizon Protocol Seven Documents/Japanese/THP-7_en.md
@@ -1,0 +1,156 @@
+REFINED_BY_CODEX: 2025-09-17T00:00:00Z
+REFINED_BY_CODEX: 2025-09-17T00:00:00Z
+
+AUDIT_TRAIL:
+AUDIT_TRAIL:
+
+- 2025-09-17T00:00:00Z 翻訳 (JP→EN) と指標用語の整合を実施。
+- 2025-09-17T00:00:00Z Executed JP-to-EN translation with KPI terminology alignment.
+
+# THP-7: Ops KPI Dashboard - 運用計測基盤
+# THP-7: Ops KPI Dashboard - Operations Measurement Platform
+
+**Version:** Ops-KPI-Dashboard rev.3.1 (Walpurgis Edition)** **最終更新：2025年9月15日 JST**
+**Version:** Ops-KPI-Dashboard rev.3.1 (Walpurgis Edition)** **Last Updated: 15 September 2025 JST**
+
+## Level 1: 司令部サマリー（作戦発動ステータス）
+## Level 1: Command Summary (Operation Activation Status)
+
+### 市場『無風』の定義値（数値閾値）
+### Definition of “Calm Markets” (Numerical Thresholds)
+
+- VIX：3営業日移動で変動幅が±5%以内 かつ 水準 < 20。
+- VIX: 3-trading-day moving change within ±5% and level < 20.
+- MOVE：100 以下継続（3営業日）。
+- MOVE: Sustained ≤ 100 for three trading days.
+- 米10年金利・実効ボラ（20日年率化）：≤ 75bp。
+- U.S. 10-year yield realized volatility (annualized over 20 days): ≤ 75 bp.
+- 上記が同時充足：無風=GREEN。2/3充足：注意=YELLOW。未充足：平常=WHITE。
+- All thresholds met: Calm = GREEN. Two of three met: Watch = YELLOW. Unmet: Normal = WHITE.
+
+**目的：1分で世界の状況を把握し、THPの自動執行状況を確認する。**
+**Purpose: Grasp global conditions in one minute and confirm THP’s automated execution status.**
+
+|ドメイン|現在のステータス|トリガー要因|備考|
+|Domain|Current Status|Trigger Factor|Notes|
+|---|---|---|---|
+|**グローバル金融**|🟡 **発動準備 (Armed)**|ドル信認の構造的低下（※Composite依存）|臨界トリガー監視中|
+|**Global Finance**|🟡 **Armed**|Structural decline in dollar credibility (Composite-dependent)|Monitoring critical triggers|
+|**地政学リスク**|🟡 **発動準備 (Armed)**|NATO第4条協議要請（※外部報道の確定事象に依存）|エスカレーション監視中|
+|**Geopolitical Risk**|🟡 **Armed**|Request for NATO Article 4 consultations (depends on confirmed external reporting)|Watching for escalation|
+|**社会・格差**|🟡 **発動準備 (Armed)**|格差拡大による孤立主義的ポピュリズムの強化|負の循環を監視|
+|**Society & Inequality**|🟡 **Armed**|Rise of isolationist populism driven by widening inequality|Monitoring negative cycle|
+|**資源・物流**|🟢 **正常 (Green)**|WTI価格は安定レンジ内¹|監視継続|
+|**Resources & Logistics**|🟢 **Green**|WTI prices within stable range¹|Continue monitoring|
+|**THP内部**|🟢 **正常 (Green)**|全システム正常|待機状態|
+|**Internal THP**|🟢 **Green**|All systems nominal|Standing by|
+
+¹ _原油価格は$60-80/bblの安定レンジ内。穀物指数(YoY -5%)は季節要因を含む。_
+¹ _Crude oil prices remain in the $60–80/bbl range. Grain index (YoY -5%) includes seasonal factors._
+
+## Level 2: 自動執行トリガーパネル
+## Level 2: Automated Execution Trigger Panel
+
+**目的：各領域のトリガー条件と現在のステータスを精密に監視する。トリガー超過は、THP-lifeline計画に定義されたアクションを自動的に実行する。**
+**Purpose: Monitor trigger conditions and current status across each domain in detail. Exceeding a trigger automatically executes actions defined in the THP-lifeline plan.**
+
+### 1. グローバル金融市場
+### 1. Global Financial Markets
+
+**サマリー：ドルからの信認逃避は継続。Tricolor社の破綻はサブプライム市場への前震であり、監視を強化する。**
+**Summary: Flight from the dollar continues. The failure of Tricolor is a foreshock for the subprime market; tighten monitoring.**
+
+|KPI|単位|現在値|**執行トリガー (Execution Trigger)**|ステータス|
+|KPI|Unit|Current Value|**Execution Trigger**|Status|
+|---|---|---|---|---|
+|**UST入札：テール (10Y/30Y)²**|bp|+1.5|≥ +5|🟢 GREEN|
+|**UST Auction Tail (10Y/30Y)²**|bp|+1.5|≥ +5|🟢 GREEN|
+|**UST入札：応札倍率²**|x|2.45|< 2.10|🟢 GREEN|
+|**UST Auction Bid-to-Cover²**|x|2.45|< 2.10|🟢 GREEN|
+|**UST入札：間接比率²**|%|62|< 50|🟢 GREEN|
+|**UST Auction Indirect Share²**|%|62|< 50|🟢 GREEN|
+|**FRA–OIS 3M**|bp|25|> 70|🟢 GREEN|
+|**FRA–OIS 3M**|bp|25|> 70|🟢 GREEN|
+|**MOVE (金利ボラ)**|index|110|≥ 170|🟢 GREEN|
+|**MOVE (Rate Volatility)**|index|110|≥ 170|🟢 GREEN|
+|**X-Currency Basis: USD/JPY**|bp|-40|≤ −80|🟢 GREEN|
+|**X-Currency Basis: USD/JPY**|bp|-40|≤ −80|🟢 GREEN|
+|**HY OAS**|bp|350|≥500(🟡) / ≥600(🔴)|🟡 **WATCH**|
+|**HY OAS**|bp|350|≥500 (🟡) / ≥600 (🔴)|🟡 **WATCH**|
+|**サブプライム自動車ローンABS (BBB) スプレッド**|bp|大幅拡大|> 450|🟡 **WATCH**|
+|**Subprime Auto Loan ABS (BBB) Spread**|bp|Surging|> 450|🟡 **WATCH**|
+|**DXY（ドル指数）³**|index|97.5|※Composite依存|🟢 GREEN|
+|**DXY (Dollar Index)³**|index|97.5|Composite-dependent|🟢 GREEN|
+|**金価格³**|USD/oz|3,679|※Composite依存|🟢 GREEN|
+|**Gold Price³**|USD/oz|3,679|Composite-dependent|🟢 GREEN|
+
+² _上記3項目は「3点同時到達」によりAMBER/REDへ格上げ。_ ³ _DXY×Gold×WTIが同時上昇した場合に限りAMBER/REDへ格上げ。単独では判定しない。_
+² _Elevate to AMBER/RED only when the three marked items hit thresholds simultaneously._ ³ _Upgrade to AMBER/RED only when DXY, gold, and WTI rise together; no single indicator triggers escalation._
+
+### 2. 地政学リスク
+### 2. Geopolitical Risk
+
+**サマリー：軍事行動の予測は行わない。検証・確定された政治・法的事象のみをトリガーとして扱う。**
+**Summary: Do not forecast military action; only verified and confirmed political or legal events act as triggers.**
+
+|KPI|単位|現在値/状況|**執行トリガー (Execution Trigger)**|ステータス|
+|KPI|Unit|Current Value / Status|**Execution Trigger**|Status|
+|---|---|---|---|---|
+|**NATO第4条**|N/A|協議要請（Formal未了）|**正式発動**|🟡 ARMED|
+|**NATO Article 4**|N/A|Consultation request (formalization pending)|**Formal invocation**|🟡 ARMED|
+|**BTP-Bund 10Y スプレッド**|bp|95|> 100|🟢 GREEN|
+|**BTP-Bund 10Y Spread**|bp|95|> 100|🟢 GREEN|
+|**CNH/CNY スプレッド**|pips|15|≥100(🟡) / ≥200(🔴)|🟢 GREEN|
+|**CNH/CNY Spread**|pips|15|≥100 (🟡) / ≥200 (🔴)|🟢 GREEN|
+|**香港CRE空室率**|%|19|> 20% & NPL急増|🟡 ARMED|
+|**Hong Kong CRE Vacancy Rate**|%|19|> 20% plus surge in NPLs|🟡 ARMED|
+
+### 3. 社会・格差
+### 3. Society and Inequality
+
+**サマリー：富の偏在はワルプルギス直撃層（下位50％）を生み、抗議すらできない“悪性の安定”を形成。その結果、孤立主義的ポピュリズムが強化され、さらに格差が拡大する負の循環を監視対象とする。**
+**Summary: Wealth concentration creates a Walpurgis-struck cohort (bottom 50%) and a malignant stability that suppresses protest. The resulting isolationist populism amplifies inequality; monitor this negative loop.**
+
+|KPI|単位|現在値/状況|**執行トリガー (Execution Trigger)**|ステータス|
+|KPI|Unit|Current Value / Status|**Execution Trigger**|Status|
+|---|---|---|---|---|
+|**下位50％の資産シェア**|%|2.5|≤2.0 に低下|🟡 WATCH|
+|**Asset Share of Bottom 50%**|%|2.5|Drops to ≤ 2.0|🟡 WATCH|
+|**格差ナラティブ発話（トランプ節等）**|件/月|増加中|同一週に「海外支援批判＋家計簿財政言説」が重なる|🟡 WATCH|
+|**Inequality Narrative Incidents (e.g., Trumpist rhetoric)**|cases/month|Rising|Same week combines “anti-foreign-aid” and “household-budget fiscal” rhetoric|🟡 WATCH|
+|**暴動・抗議件数**|件/月|極小（沈静化）|「抗議行動ゼロ」＋インフレ率上昇が同時観測|🔴 ALERT|
+|**Riots / Protests**|cases/month|Minimal (subdued)|“Zero protests” observed alongside rising inflation|🔴 ALERT|
+
+### 4. 資源・物流・その他
+### 4. Resources, Logistics, and Other Items
+
+**サマリー：エネルギー・食料市場は安定。ミクロな信用リスクは監視を継続。**
+**Summary: Energy and food markets remain stable; continue monitoring micro-level credit risk.**
+
+|KPI|単位|現在値|**執行トリガー (Execution Trigger)**|ステータス|
+|KPI|Unit|Current Value|**Execution Trigger**|Status|
+|---|---|---|---|---|
+|**原油 WTI**|USD/bbl|72|≥ 80 or ≤ 60|🟢 GREEN|
+|**Crude Oil WTI**|USD/bbl|72|≥ 80 or ≤ 60|🟢 GREEN|
+|**穀物指数 (YoY)**|%|-5|≥ +30|🟢 GREEN|
+|**Grain Index (YoY)**|%|-5|≥ +30|🟢 GREEN|
+|**Chapter11件数 (週)**|件|4|> 10 (特定セクター)|🟢 GREEN|
+|**Chapter 11 Filings (weekly)**|cases|4|> 10 (specific sector)|🟢 GREEN|
+
+### 民族・文化紛争KPI（People-Charter接続）
+### Ethno-Cultural Conflict KPIs (Linked to People Charter)
+
+- 強制移住（7日累計）：>10,000＝🔶警報、>30,000＝🔴制裁起動提案。
+- Forced displacement (7-day total): >10,000 = 🔶 Alert, >30,000 = 🔴 Sanction activation proposal.
+- 民間人殺傷（週／10万人）：>5＝🔶、>20＝🔴（UN-PDF審査）。
+- Civilian casualties (weekly per 100,000): >5 = 🔶, >20 = 🔴 (UN-PDF review).
+- 宗教施設攻撃：1件🔶／3件連続🔴。
+- Attacks on religious facilities: 1 incident = 🔶 / 3 consecutive incidents = 🔴.
+- 合意不履行（監督評価×）：連続2期で金融制裁段階1を自動提案。
+- Agreement breaches (oversight rating ×): Two consecutive periods automatically propose Financial Sanction Stage 1.
+
+### 版管理（命名統一）
+### Version Control (Naming Standardization)
+
+- 本ドキュメントの表題は**THP-7_Ops_KPI_Dashboard-運用計測基盤**で統一する（別名の重複版は廃止）。
+- Standardize the title of this document as **THP-7_Ops_KPI_Dashboard-運用計測基盤** (retire duplicate versions under other names).

--- a/[Paramount]Workflow/【最重要】The Horizon Protocol (THP)/1st-The Horizon Protocol Seven Documents/Japanese/summary.json
+++ b/[Paramount]Workflow/【最重要】The Horizon Protocol (THP)/1st-The Horizon Protocol Seven Documents/Japanese/summary.json
@@ -1,0 +1,35 @@
+{
+  "_audit": {
+    "refined_by": "REFINED_BY_CODEX: 2025-09-17T00:00:00Z",
+    "timestamp": "2025-09-17T00:00:00Z",
+    "actions": ["generate_summary"]
+  },
+  "THP-1_World_Redefinition_Charter-世界再定義宣言.md": {
+    "output_file": "THP-1_en.md",
+    "actions_taken": ["translate"]
+  },
+  "THP-2_Ethics_Charter-倫理憲章.md": {
+    "output_file": "THP-2_en.md",
+    "actions_taken": ["translate"]
+  },
+  "THP-3_People_Charter-民族憲章.md": {
+    "output_file": "THP-3_en.md",
+    "actions_taken": ["translate"]
+  },
+  "THP-4_Religion_Charter-宗教憲章.md": {
+    "output_file": "THP-4_en.md",
+    "actions_taken": ["refine", "translate"]
+  },
+  "THP-5_Lexicon-用語辞書.md": {
+    "output_file": "THP-5_en.md",
+    "actions_taken": ["translate"]
+  },
+  "THP-6_Appendix-補遺.md": {
+    "output_file": "THP-6_en.md",
+    "actions_taken": ["refine", "translate"]
+  },
+  "THP-7_Ops_KPI_Dashboard-運用計測基盤.md": {
+    "output_file": "THP-7_en.md",
+    "actions_taken": ["translate"]
+  }
+}


### PR DESCRIPTION
## Summary
- translate THP-1 through THP-3, THP-5, and THP-7 into parallel Japanese-English markdown with audit headers
- refine THP-4 religion charter per specified wording updates and add translation note while delivering bilingual output
- canonicalize LSC axioms in THP-6, document legacy variations, and provide the requested summary manifest

## Testing
- not run (non-code changes)


------
https://chatgpt.com/codex/tasks/task_e_68c98f8a833c8333b23b037cef94aff0